### PR TITLE
chore(deps): bump vt100-rust to a5ff023

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3459,7 +3459,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vt100"
 version = "0.15.2"
-source = "git+https://github.com/kota65535/vt100-rust?rev=cc4bd1eb6f1e302eaa5a5f24d5bed02a4244d0c6#cc4bd1eb6f1e302eaa5a5f24d5bed02a4244d0c6"
+source = "git+https://github.com/kota65535/vt100-rust?rev=a5ff023e9f2317e3d049fc76a4de28becb25a103#a5ff023e9f2317e3d049fc76a4de28becb25a103"
 dependencies = [
  "itoa",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 tui-term = { version = "=0.1.9", default-features = false }
 unicode-width = "0.1.14"
-vt100 = { git = "https://github.com/kota65535/vt100-rust", rev = "cc4bd1eb6f1e302eaa5a5f24d5bed02a4244d0c6" }
+vt100 = { git = "https://github.com/kota65535/vt100-rust", rev = "a5ff023e9f2317e3d049fc76a4de28becb25a103" }
 which = "8.0.0"
 
 # The profile that 'dist' will build with


### PR DESCRIPTION
## Summary
- Bump `vt100` git dependency to [a5ff023](https://github.com/kota65535/vt100-rust/commit/a5ff023e9f2317e3d049fc76a4de28becb25a103).
- Prevent panic in entire_screen rows_formatted when scrollback > u16::MAX 

## Test plan
- [ ] `cargo build`
- [ ] `cargo test`