### PR TITLE
feat(tui): word selection on double-click, line selection on triple-click

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3459,7 +3459,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vt100"
 version = "0.15.2"
-source = "git+https://github.com/kota65535/vt100-rust?rev=a5ff023e9f2317e3d049fc76a4de28becb25a103#a5ff023e9f2317e3d049fc76a4de28becb25a103"
+source = "git+https://github.com/kota65535/vt100-rust?rev=580026b#580026bda7e051a735f076860966a480d04c2833"
 dependencies = [
  "itoa",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 tui-term = { version = "=0.1.9", default-features = false }
 unicode-width = "0.1.14"
-vt100 = { git = "https://github.com/kota65535/vt100-rust", rev = "a5ff023e9f2317e3d049fc76a4de28becb25a103" }
+vt100 = { git = "https://github.com/kota65535/vt100-rust", rev = "580026b" }
 which = "8.0.0"
 
 # The profile that 'dist' will build with

--- a/firepit.yml
+++ b/firepit.yml
@@ -1,9 +1,0 @@
-tasks:
-  bbb:
-    env:
-      LC_ALL: C
-    command: echo "           aaaaa bbbb                      https://github.com/toggle-inc/infra/pull/164"
-  aaa:
-    env:
-      LC_ALL: C
-    command: "seq 1 100000"

--- a/firepit.yml
+++ b/firepit.yml
@@ -1,0 +1,9 @@
+tasks:
+  bbb:
+    env:
+      LC_ALL: C
+    command: echo "           aaaaa bbbb                      https://github.com/toggle-inc/infra/pull/164"
+  aaa:
+    env:
+      LC_ALL: C
+    command: "seq 1 100000"

--- a/firepit.yml
+++ b/firepit.yml
@@ -1,0 +1,9 @@
+tasks:
+  bbb:
+    env:
+      LC_ALL: C
+    command: echo "                                 https://github.com/toggle-inc/infra/pull/164"
+  aaa:
+    env:
+      LC_ALL: C
+    command: "seq 1 100000"

--- a/firepit.yml
+++ b/firepit.yml
@@ -1,9 +1,0 @@
-tasks:
-  bbb:
-    env:
-      LC_ALL: C
-    command: echo "                                 https://github.com/toggle-inc/infra/pull/164"
-  aaa:
-    env:
-      LC_ALL: C
-    command: "seq 1 100000"

--- a/src/app/command.rs
+++ b/src/app/command.rs
@@ -84,6 +84,10 @@ pub enum AppCommand {
         cols: u16,
         edge: Option<Direction>,
     },
+    WordSelection {
+        rows: u16,
+        cols: u16,
+    },
     LineSelection {
         rows: u16,
     },

--- a/src/app/tui/input.rs
+++ b/src/app/tui/input.rs
@@ -135,16 +135,25 @@ impl InputHandler {
             (MouseEventKind::ScrollUp, false) => Some(AppCommand::ScrollUp(ScrollSize::One)),
             (MouseEventKind::Down(MouseButton::Left), true) => Some(AppCommand::Select { index: row as usize }),
             (MouseEventKind::Down(MouseButton::Left), false) => {
-                self.click_times.push(Instant::now());
-                let num_clicks = self.num_of_multiple_clicks();
-                if num_clicks == 1 {
-                    Some(AppCommand::ClickPane { row, col: column })
-                } else if num_clicks == 2 {
-                    debug!("Double-clicked: word selection");
-                    Some(AppCommand::WordSelection { rows: row, cols: column })
+                let has_open_modifier = if cfg!(target_os = "macos") {
+                    mouse_event.modifiers.contains(KeyModifiers::SUPER)
                 } else {
-                    debug!("Triple-clicked: line selection");
-                    Some(AppCommand::LineSelection { rows: row })
+                    mouse_event.modifiers.contains(KeyModifiers::CONTROL)
+                };
+                if has_open_modifier {
+                    Some(AppCommand::ClickPane { row, col: column })
+                } else {
+                    self.click_times.push(Instant::now());
+                    let num_clicks = self.num_of_multiple_clicks();
+                    if num_clicks == 1 {
+                        Some(AppCommand::ClearSelection)
+                    } else if num_clicks == 2 {
+                        debug!("Double-clicked: word selection");
+                        Some(AppCommand::WordSelection { rows: row, cols: column })
+                    } else {
+                        debug!("Triple-clicked: line selection");
+                        Some(AppCommand::LineSelection { rows: row })
+                    }
                 }
             }
             (MouseEventKind::Moved, false) => Some(AppCommand::HoverPane { row, col: column }),

--- a/src/app/tui/input.rs
+++ b/src/app/tui/input.rs
@@ -139,8 +139,11 @@ impl InputHandler {
                 let num_clicks = self.num_of_multiple_clicks();
                 if num_clicks == 1 {
                     Some(AppCommand::ClearSelection)
+                } else if num_clicks == 2 {
+                    debug!("Double-clicked: word selection");
+                    Some(AppCommand::WordSelection { rows: row, cols: column })
                 } else {
-                    debug!("Clicked {} times", num_clicks);
+                    debug!("Triple-clicked: line selection");
                     Some(AppCommand::LineSelection { rows: row })
                 }
             }

--- a/src/app/tui/input.rs
+++ b/src/app/tui/input.rs
@@ -16,8 +16,8 @@ use tracing::debug;
 pub struct InputHandler {
     click_times: RingBuffer<Instant>,
     /// Set on single-click Down, cleared on Drag or multi-click.
-    /// If still set on Up, we open the hovered URL.
-    may_open_url: bool,
+    /// If still set on Up, the click is dispatched as ClickPane.
+    click_not_dragged: bool,
 }
 
 pub struct InputOptions<'a> {
@@ -51,7 +51,7 @@ impl InputHandler {
     pub fn new() -> Self {
         Self {
             click_times: RingBuffer::new(3),
-            may_open_url: false,
+            click_not_dragged: false,
         }
     }
 
@@ -142,21 +142,21 @@ impl InputHandler {
                 self.click_times.push(Instant::now());
                 let num_clicks = self.num_of_multiple_clicks();
                 if num_clicks == 1 {
-                    self.may_open_url = true;
+                    self.click_not_dragged = true;
                     Some(AppCommand::ClearSelection)
                 } else if num_clicks == 2 {
-                    self.may_open_url = false;
+                    self.click_not_dragged = false;
                     debug!("Double-clicked: word selection");
                     Some(AppCommand::WordSelection { rows: row, cols: column })
                 } else {
-                    self.may_open_url = false;
+                    self.click_not_dragged = false;
                     debug!("Triple-clicked: line selection");
                     Some(AppCommand::LineSelection { rows: row })
                 }
             }
             (MouseEventKind::Up(MouseButton::Left), false) => {
-                if self.may_open_url {
-                    self.may_open_url = false;
+                if self.click_not_dragged {
+                    self.click_not_dragged = false;
                     Some(AppCommand::ClickPane { row, col: column })
                 } else {
                     None
@@ -164,7 +164,7 @@ impl InputHandler {
             }
             (MouseEventKind::Moved, false) => Some(AppCommand::HoverPane { row, col: column }),
             (MouseEventKind::Drag(MouseButton::Left), _) => {
-                self.may_open_url = false;
+                self.click_not_dragged = false;
                 Some(AppCommand::UpdateSelection {
                     rows: row,
                     cols: column,

--- a/src/app/tui/input.rs
+++ b/src/app/tui/input.rs
@@ -15,6 +15,9 @@ use tracing::debug;
 #[derive(Debug, Clone)]
 pub struct InputHandler {
     click_times: RingBuffer<Instant>,
+    /// Set on single-click Down, cleared on Drag or multi-click.
+    /// If still set on Up, we open the hovered URL.
+    pending_url_click: bool,
 }
 
 pub struct InputOptions<'a> {
@@ -48,6 +51,7 @@ impl InputHandler {
     pub fn new() -> Self {
         Self {
             click_times: RingBuffer::new(3),
+            pending_url_click: false,
         }
     }
 
@@ -135,33 +139,38 @@ impl InputHandler {
             (MouseEventKind::ScrollUp, false) => Some(AppCommand::ScrollUp(ScrollSize::One)),
             (MouseEventKind::Down(MouseButton::Left), true) => Some(AppCommand::Select { index: row as usize }),
             (MouseEventKind::Down(MouseButton::Left), false) => {
-                let has_open_modifier = if cfg!(target_os = "macos") {
-                    mouse_event.modifiers.contains(KeyModifiers::SUPER)
+                self.click_times.push(Instant::now());
+                let num_clicks = self.num_of_multiple_clicks();
+                if num_clicks == 1 {
+                    self.pending_url_click = true;
+                    Some(AppCommand::ClearSelection)
+                } else if num_clicks == 2 {
+                    self.pending_url_click = false;
+                    debug!("Double-clicked: word selection");
+                    Some(AppCommand::WordSelection { rows: row, cols: column })
                 } else {
-                    mouse_event.modifiers.contains(KeyModifiers::CONTROL)
-                };
-                if has_open_modifier {
+                    self.pending_url_click = false;
+                    debug!("Triple-clicked: line selection");
+                    Some(AppCommand::LineSelection { rows: row })
+                }
+            }
+            (MouseEventKind::Up(MouseButton::Left), false) => {
+                if self.pending_url_click {
+                    self.pending_url_click = false;
                     Some(AppCommand::ClickPane { row, col: column })
                 } else {
-                    self.click_times.push(Instant::now());
-                    let num_clicks = self.num_of_multiple_clicks();
-                    if num_clicks == 1 {
-                        Some(AppCommand::ClearSelection)
-                    } else if num_clicks == 2 {
-                        debug!("Double-clicked: word selection");
-                        Some(AppCommand::WordSelection { rows: row, cols: column })
-                    } else {
-                        debug!("Triple-clicked: line selection");
-                        Some(AppCommand::LineSelection { rows: row })
-                    }
+                    None
                 }
             }
             (MouseEventKind::Moved, false) => Some(AppCommand::HoverPane { row, col: column }),
-            (MouseEventKind::Drag(MouseButton::Left), _) => Some(AppCommand::UpdateSelection {
-                rows: row,
-                cols: column,
-                edge,
-            }),
+            (MouseEventKind::Drag(MouseButton::Left), _) => {
+                self.pending_url_click = false;
+                Some(AppCommand::UpdateSelection {
+                    rows: row,
+                    cols: column,
+                    edge,
+                })
+            }
             _ => None,
         }
     }

--- a/src/app/tui/input.rs
+++ b/src/app/tui/input.rs
@@ -17,7 +17,7 @@ pub struct InputHandler {
     click_times: RingBuffer<Instant>,
     /// Set on single-click Down, cleared on Drag or multi-click.
     /// If still set on Up, we open the hovered URL.
-    pending_url_click: bool,
+    may_open_url: bool,
 }
 
 pub struct InputOptions<'a> {
@@ -51,7 +51,7 @@ impl InputHandler {
     pub fn new() -> Self {
         Self {
             click_times: RingBuffer::new(3),
-            pending_url_click: false,
+            may_open_url: false,
         }
     }
 
@@ -142,21 +142,21 @@ impl InputHandler {
                 self.click_times.push(Instant::now());
                 let num_clicks = self.num_of_multiple_clicks();
                 if num_clicks == 1 {
-                    self.pending_url_click = true;
+                    self.may_open_url = true;
                     Some(AppCommand::ClearSelection)
                 } else if num_clicks == 2 {
-                    self.pending_url_click = false;
+                    self.may_open_url = false;
                     debug!("Double-clicked: word selection");
                     Some(AppCommand::WordSelection { rows: row, cols: column })
                 } else {
-                    self.pending_url_click = false;
+                    self.may_open_url = false;
                     debug!("Triple-clicked: line selection");
                     Some(AppCommand::LineSelection { rows: row })
                 }
             }
             (MouseEventKind::Up(MouseButton::Left), false) => {
-                if self.pending_url_click {
-                    self.pending_url_click = false;
+                if self.may_open_url {
+                    self.may_open_url = false;
                     Some(AppCommand::ClickPane { row, col: column })
                 } else {
                     None
@@ -164,7 +164,7 @@ impl InputHandler {
             }
             (MouseEventKind::Moved, false) => Some(AppCommand::HoverPane { row, col: column }),
             (MouseEventKind::Drag(MouseButton::Left), _) => {
-                self.pending_url_click = false;
+                self.may_open_url = false;
                 Some(AppCommand::UpdateSelection {
                     rows: row,
                     cols: column,

--- a/src/app/tui/input.rs
+++ b/src/app/tui/input.rs
@@ -17,7 +17,7 @@ pub struct InputHandler {
     click_times: RingBuffer<Instant>,
     /// Set on single-click Down, cleared on Drag or multi-click.
     /// If still set on Up, the click is dispatched as ClickPane.
-    click_not_dragged: bool,
+    is_single_click: bool,
 }
 
 pub struct InputOptions<'a> {
@@ -51,7 +51,7 @@ impl InputHandler {
     pub fn new() -> Self {
         Self {
             click_times: RingBuffer::new(3),
-            click_not_dragged: false,
+            is_single_click: false,
         }
     }
 
@@ -142,21 +142,21 @@ impl InputHandler {
                 self.click_times.push(Instant::now());
                 let num_clicks = self.num_of_multiple_clicks();
                 if num_clicks == 1 {
-                    self.click_not_dragged = true;
+                    self.is_single_click = true;
                     Some(AppCommand::ClearSelection)
                 } else if num_clicks == 2 {
-                    self.click_not_dragged = false;
+                    self.is_single_click = false;
                     debug!("Double-clicked: word selection");
                     Some(AppCommand::WordSelection { rows: row, cols: column })
                 } else {
-                    self.click_not_dragged = false;
+                    self.is_single_click = false;
                     debug!("Triple-clicked: line selection");
                     Some(AppCommand::LineSelection { rows: row })
                 }
             }
             (MouseEventKind::Up(MouseButton::Left), false) => {
-                if self.click_not_dragged {
-                    self.click_not_dragged = false;
+                if self.is_single_click {
+                    self.is_single_click = false;
                     Some(AppCommand::ClickPane { row, col: column })
                 } else {
                     None
@@ -164,7 +164,7 @@ impl InputHandler {
             }
             (MouseEventKind::Moved, false) => Some(AppCommand::HoverPane { row, col: column }),
             (MouseEventKind::Drag(MouseButton::Left), _) => {
-                self.click_not_dragged = false;
+                self.is_single_click = false;
                 Some(AppCommand::UpdateSelection {
                     rows: row,
                     cols: column,

--- a/src/app/tui/input.rs
+++ b/src/app/tui/input.rs
@@ -137,7 +137,10 @@ impl InputHandler {
             (MouseEventKind::ScrollDown, false) => Some(AppCommand::ScrollDown(ScrollSize::One)),
             (MouseEventKind::ScrollUp, true) => Some(AppCommand::Up),
             (MouseEventKind::ScrollUp, false) => Some(AppCommand::ScrollUp(ScrollSize::One)),
-            (MouseEventKind::Down(MouseButton::Left), true) => Some(AppCommand::Select { index: row as usize }),
+            (MouseEventKind::Down(MouseButton::Left), true) => {
+                self.is_single_click = false;
+                Some(AppCommand::Select { index: row as usize })
+            }
             (MouseEventKind::Down(MouseButton::Left), false) => {
                 self.click_times.push(Instant::now());
                 let num_clicks = self.num_of_multiple_clicks();

--- a/src/app/tui/mod.rs
+++ b/src/app/tui/mod.rs
@@ -536,6 +536,12 @@ impl TuiAppState {
         Ok(())
     }
 
+    pub fn word_selection(&mut self, rows: u16, cols: u16) -> anyhow::Result<()> {
+        let task = self.active_task_mut()?;
+        task.output.word_selection(rows, cols);
+        Ok(())
+    }
+
     pub fn line_selection(&mut self, rows: u16) -> anyhow::Result<()> {
         let task = self.active_task_mut()?;
         task.output.line_selection(rows);
@@ -868,6 +874,9 @@ impl TuiAppState {
             }
             AppCommand::ClearSelection => {
                 self.clear_selection()?;
+            }
+            AppCommand::WordSelection { rows, cols } => {
+                self.word_selection(rows, cols)?;
             }
             AppCommand::LineSelection { rows } => {
                 self.line_selection(rows)?;

--- a/src/app/tui/mod.rs
+++ b/src/app/tui/mod.rs
@@ -933,8 +933,6 @@ impl TuiAppState {
                         let url = url_span.url.clone();
                         self.open_url(&url);
                     }
-                } else {
-                    self.clear_selection()?;
                 }
             }
             AppCommand::OpenUrl { url } => {

--- a/src/app/tui/term_output.rs
+++ b/src/app/tui/term_output.rs
@@ -147,7 +147,7 @@ impl TerminalOutput {
             (start, end)
         };
 
-        self.parser.screen_mut().set_selection(row, start_col, row, end_col + 1);
+        self.parser.screen_mut().set_selection(row, start_col, row, end_col);
     }
 
     pub fn line_selection(&mut self, row: u16) {

--- a/src/app/tui/term_output.rs
+++ b/src/app/tui/term_output.rs
@@ -128,9 +128,15 @@ impl TerminalOutput {
                     return false;
                 };
                 match visible_row.get(c) {
+                    Some(cell) if cell.is_wide_continuation() => {
+                        c > 0 && visible_row.get(c - 1).is_some_and(|prev| {
+                            let contents = prev.contents();
+                            !contents.is_empty() && !contents.chars().all(|ch| ch.is_whitespace())
+                        })
+                    }
                     Some(cell) => {
                         let contents = cell.contents();
-                        !contents.is_empty() && !contents.chars().all(|ch| ch == ' ' || ch == '\0')
+                        !contents.is_empty() && !contents.chars().all(|ch| ch.is_whitespace())
                     }
                     None => false,
                 }

--- a/src/app/tui/term_output.rs
+++ b/src/app/tui/term_output.rs
@@ -109,45 +109,82 @@ impl TerminalOutput {
     }
 
     pub fn word_selection(&mut self, row: u16, col: u16) {
-        let (start_col, end_col) = {
+        let selection = {
             let screen = self.parser.screen();
-            let Some(visible_row) = screen.grid().visible_row(row) else {
-                return;
-            };
             let size = screen.size();
             let cols = size.1;
+            let wrapped_flags: Vec<bool> = screen.grid().visible_rows().map(|r| r.wrapped()).collect();
+            if wrapped_flags.is_empty() {
+                return;
+            }
+            let max_row = wrapped_flags.len().saturating_sub(1) as u16;
+            let row = row.min(max_row);
             let col = col.min(cols.saturating_sub(1));
 
             // Classify each cell as whitespace or word (non-whitespace).
             // Using only two classes allows double-click to select URLs, file paths, etc.
-            let is_word = |c: u16| -> bool {
+            let is_word = |r: u16, c: u16| -> bool {
+                let Some(visible_row) = screen.grid().visible_row(r) else {
+                    return false;
+                };
                 match visible_row.get(c) {
                     Some(cell) => {
                         let contents = cell.contents();
-                        !contents.is_empty() && !contents.chars().all(|c| c == ' ' || c == '\0')
+                        !contents.is_empty() && !contents.chars().all(|ch| ch == ' ' || ch == '\0')
                     }
                     None => false,
                 }
             };
 
-            let target_is_word = is_word(col);
+            let target_is_word = is_word(row, col);
 
-            // Expand left
-            let mut start = col;
-            while start > 0 && is_word(start - 1) == target_is_word {
-                start -= 1;
+            // Expand left, crossing wrapped line boundaries
+            let (mut start_row, mut start_col) = (row, col);
+            loop {
+                if start_col > 0 {
+                    if is_word(start_row, start_col - 1) == target_is_word {
+                        start_col -= 1;
+                    } else {
+                        break;
+                    }
+                } else if start_row > 0 && wrapped_flags[start_row as usize - 1] {
+                    if is_word(start_row - 1, cols - 1) == target_is_word {
+                        start_row -= 1;
+                        start_col = cols - 1;
+                    } else {
+                        break;
+                    }
+                } else {
+                    break;
+                }
             }
 
-            // Expand right
-            let mut end = col;
-            while end + 1 < cols && is_word(end + 1) == target_is_word {
-                end += 1;
+            // Expand right, crossing wrapped line boundaries
+            let (mut end_row, mut end_col) = (row, col);
+            loop {
+                if end_col + 1 < cols {
+                    if is_word(end_row, end_col + 1) == target_is_word {
+                        end_col += 1;
+                    } else {
+                        break;
+                    }
+                } else if wrapped_flags.get(end_row as usize) == Some(&true) {
+                    if is_word(end_row + 1, 0) == target_is_word {
+                        end_row += 1;
+                        end_col = 0;
+                    } else {
+                        break;
+                    }
+                } else {
+                    break;
+                }
             }
 
-            (start, end)
+            (start_row, start_col, end_row, end_col)
         };
 
-        self.parser.screen_mut().set_selection(row, start_col, row, end_col);
+        let (start_row, start_col, end_row, end_col) = selection;
+        self.parser.screen_mut().set_selection(start_row, start_col, end_row, end_col);
     }
 
     pub fn line_selection(&mut self, row: u16) {

--- a/src/app/tui/term_output.rs
+++ b/src/app/tui/term_output.rs
@@ -184,9 +184,6 @@ impl TerminalOutput {
         };
 
         let (start_row, start_col, end_row, end_col) = selection;
-        // vt100's selection_cells treats end_col as inclusive for single-row selections
-        // but exclusive for the last row of multi-row selections, so adjust accordingly.
-        let end_col = if start_row == end_row { end_col } else { end_col + 1 };
         self.parser.screen_mut().set_selection(start_row, start_col, end_row, end_col);
     }
 

--- a/src/app/tui/term_output.rs
+++ b/src/app/tui/term_output.rs
@@ -184,6 +184,9 @@ impl TerminalOutput {
         };
 
         let (start_row, start_col, end_row, end_col) = selection;
+        // vt100's selection_cells treats end_col as inclusive for single-row selections
+        // but exclusive for the last row of multi-row selections, so adjust accordingly.
+        let end_col = if start_row == end_row { end_col } else { end_col + 1 };
         self.parser.screen_mut().set_selection(start_row, start_col, end_row, end_col);
     }
 

--- a/src/app/tui/term_output.rs
+++ b/src/app/tui/term_output.rs
@@ -118,34 +118,29 @@ impl TerminalOutput {
             let cols = size.1;
             let col = col.min(cols.saturating_sub(1));
 
-            // Get the character class at the clicked position
-            let char_class = |c: u16| -> u8 {
+            // Classify each cell as whitespace or word (non-whitespace).
+            // Using only two classes allows double-click to select URLs, file paths, etc.
+            let is_word = |c: u16| -> bool {
                 match visible_row.get(c) {
                     Some(cell) => {
                         let contents = cell.contents();
-                        if contents.is_empty() || contents.chars().all(|c| c == ' ' || c == '\0') {
-                            0 // whitespace
-                        } else if contents.chars().all(|c| c.is_alphanumeric() || c == '_') {
-                            1 // word character
-                        } else {
-                            2 // punctuation / other
-                        }
+                        !contents.is_empty() && !contents.chars().all(|c| c == ' ' || c == '\0')
                     }
-                    None => 0,
+                    None => false,
                 }
             };
 
-            let target_class = char_class(col);
+            let target_is_word = is_word(col);
 
             // Expand left
             let mut start = col;
-            while start > 0 && char_class(start - 1) == target_class {
+            while start > 0 && is_word(start - 1) == target_is_word {
                 start -= 1;
             }
 
             // Expand right
             let mut end = col;
-            while end + 1 < cols && char_class(end + 1) == target_class {
+            while end + 1 < cols && is_word(end + 1) == target_is_word {
                 end += 1;
             }
 

--- a/src/app/tui/term_output.rs
+++ b/src/app/tui/term_output.rs
@@ -108,6 +108,53 @@ impl TerminalOutput {
         self.parser.screen_mut().update_selection(row, col);
     }
 
+    pub fn word_selection(&mut self, row: u16, col: u16) {
+        let (start_col, end_col) = {
+            let screen = self.parser.screen();
+            let Some(visible_row) = screen.grid().visible_row(row) else {
+                return;
+            };
+            let size = screen.size();
+            let cols = size.1;
+            let col = col.min(cols.saturating_sub(1));
+
+            // Get the character class at the clicked position
+            let char_class = |c: u16| -> u8 {
+                match visible_row.get(c) {
+                    Some(cell) => {
+                        let contents = cell.contents();
+                        if contents.is_empty() || contents.chars().all(|c| c == ' ' || c == '\0') {
+                            0 // whitespace
+                        } else if contents.chars().all(|c| c.is_alphanumeric() || c == '_') {
+                            1 // word character
+                        } else {
+                            2 // punctuation / other
+                        }
+                    }
+                    None => 0,
+                }
+            };
+
+            let target_class = char_class(col);
+
+            // Expand left
+            let mut start = col;
+            while start > 0 && char_class(start - 1) == target_class {
+                start -= 1;
+            }
+
+            // Expand right
+            let mut end = col;
+            while end + 1 < cols && char_class(end + 1) == target_class {
+                end += 1;
+            }
+
+            (start, end)
+        };
+
+        self.parser.screen_mut().set_selection(row, start_col, row, end_col + 1);
+    }
+
     pub fn line_selection(&mut self, row: u16) {
         let (start_row, end_row, cols) = {
             let screen = self.parser.screen();


### PR DESCRIPTION
## Summary
- Double-click now selects a **word**, triple-click selects the **entire line** (including wrapped portions)
- Aligns click behavior with standard terminal emulators (iTerm2, Terminal.app, etc.)
- Word boundary detection uses `is_whitespace()` (whitespace vs non-whitespace), so URLs and file paths can be selected with a double-click
- Word selection works across soft-wrapped lines
- URL opening deferred to mouse-up: if you click and drag, text selection starts and the URL is not opened; if you click without dragging, the URL opens
- Fixed vt100 fork's `selection_cells` end_col bug for multi-row selections

## Changes
- `src/app/tui/input.rs`: Click behavior changed to `Down=ClearSelection, Up(no drag)=ClickPane, Drag=text selection, 2×Down=WordSelection, 3×Down=LineSelection`; added `is_single_click` flag to `InputHandler`
- `src/app/command.rs`: Added `WordSelection` command variant
- `src/app/tui/term_output.rs`: Implemented `word_selection()` with wrapped-line and wide character support
- `src/app/tui/mod.rs`: Added `WordSelection` command handler; `ClickPane` only opens URLs (no fallback to clear selection)
- `Cargo.toml`: Updated vt100 fork rev (multi-row selection fix)

## Test plan
- [ ] Single-click on a URL (without dragging) opens it in the browser
- [ ] Click and drag starting on a URL performs text selection without opening the URL
- [ ] Single-click on a non-URL area clears the selection
- [ ] Double-click an ASCII word to verify it is selected
- [ ] Double-click a URL to verify the URL text is selected (word selection, not opened)
- [ ] Double-click a word that spans a soft-wrapped line boundary
- [ ] Triple-click to verify the full logical line (including wrapped portions) is selected