### PR TITLE
fix(tui): remove DarkGray background from quit dialog

### DIFF
--- a/src/app/tui/dialog.rs
+++ b/src/app/tui/dialog.rs
@@ -54,7 +54,6 @@ pub fn render_quit_dialog(f: &mut Frame, force: bool) {
 
     let block = Block::default()
         .borders(Borders::ALL)
-        .bg(Color::DarkGray)
         .padding(Padding::horizontal(2));
 
     let lines = if force {


### PR DESCRIPTION
## Summary
- Remove `Color::DarkGray` background from the quit dialog, as it can blend with dark terminal theme backgrounds
- The border and `Clear` widget already provide sufficient visual separation

## Test plan
- [x] Verify quit dialog is visible on dark terminal themes
- [x] Verify quit dialog is visible on light terminal themes