### PR TITLE
fix(test): disable PTY in test runners to prevent TTY-dependent failures

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -138,6 +138,7 @@ pub async fn run() -> anyhow::Result<i32> {
         args.force,
         args.watch,
         fail_fast,
+        None
     )
     .await?;
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -33,6 +33,7 @@ impl Workspace {
         force: bool,
         watch: bool,
         fail_fast: Option<bool>,
+        use_pty: Option<bool>,
     ) -> anyhow::Result<Workspace> {
         let mut target_tasks = Vec::new();
         for task in tasks.iter() {
@@ -107,9 +108,12 @@ impl Workspace {
             children.insert(k.clone(), Project::new(k, v)?);
         }
 
-        let use_pty = match root_config.ui {
-            UI::Tui => true,
-            UI::Cui => false,
+        let use_pty = match use_pty {
+            Some(u) => u,
+            None => match root_config.ui {
+                UI::Tui => true,
+                UI::Cui => false,
+            },
         };
 
         let fail_fast = match fail_fast {

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -38,6 +38,7 @@ async fn test_env_file_not_found() {
         false,
         false,
         Some(false),
+        Some(false),
     )
     .await;
     assert_ok!(result);
@@ -56,6 +57,7 @@ async fn test_bad_env_file() {
         false,
         false,
         Some(false),
+        Some(false),
     )
     .await;
     assert_err!(result);
@@ -73,6 +75,7 @@ async fn test_multi() {
         &IndexMap::new(),
         false,
         false,
+        Some(false),
         Some(false),
     )
     .await

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -593,8 +593,7 @@ async fn run_task_inner(
 ) -> anyhow::Result<()> {
     let path = path::absolute(path)?;
     let (root, children) = ProjectConfig::new_multi(&path)?;
-    let mut ws = Workspace::new(&root, &children, &tasks, &path, &vars, force, false, Some(false)).await?;
-    ws.use_pty = false;
+    let ws = Workspace::new(&root, &children, &tasks, &path, &vars, force, false, Some(false), Some(false)).await?;
     // Create runner
     let mut runner = TaskRunner::new(&ws)?;
     let (app_tx, app_rx) = AppCommandChannel::new();
@@ -637,7 +636,7 @@ async fn run_task_with_watch<F>(
 {
     let path = path::absolute(path).unwrap();
     let (root, children) = ProjectConfig::new_multi(&path).unwrap();
-    let mut ws = Workspace::new(
+    let ws = Workspace::new(
         &root,
         &children,
         &tasks,
@@ -646,10 +645,10 @@ async fn run_task_with_watch<F>(
         force,
         true,
         Some(false),
+        Some(false),
     )
     .await
     .unwrap();
-    ws.use_pty = false;
 
     // Create runner
     let mut runner = TaskRunner::new(&ws).unwrap();

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -593,7 +593,8 @@ async fn run_task_inner(
 ) -> anyhow::Result<()> {
     let path = path::absolute(path)?;
     let (root, children) = ProjectConfig::new_multi(&path)?;
-    let ws = Workspace::new(&root, &children, &tasks, &path, &vars, force, false, Some(false)).await?;
+    let mut ws = Workspace::new(&root, &children, &tasks, &path, &vars, force, false, Some(false)).await?;
+    ws.use_pty = false;
     // Create runner
     let mut runner = TaskRunner::new(&ws)?;
     let (app_tx, app_rx) = AppCommandChannel::new();
@@ -636,7 +637,7 @@ async fn run_task_with_watch<F>(
 {
     let path = path::absolute(path).unwrap();
     let (root, children) = ProjectConfig::new_multi(&path).unwrap();
-    let ws = Workspace::new(
+    let mut ws = Workspace::new(
         &root,
         &children,
         &tasks,
@@ -648,6 +649,7 @@ async fn run_task_with_watch<F>(
     )
     .await
     .unwrap();
+    ws.use_pty = false;
 
     // Create runner
     let mut runner = TaskRunner::new(&ws).unwrap();


### PR DESCRIPTION
## Problem

Running `cargo test` locally in a terminal causes output-sensitive tests like `test_watch` to fail.

```
assertion `left == right` failed
  left: {"#bar": "bar\nbar", "#foo": "foo\nfoo", "#qux": "qux\nqux", "#baz": "baz"}
 right: {"#bar": "bar\r\n\r\n\u{4}bar", "#qux": "qux\r\n\r\n\u{4}qux", "#foo": "foo\r\n\r\n\u{4}foo", "#baz": "baz"}
```

## Root Cause

Test fixtures' `firepit.yml` do not specify a `ui` setting, so `default_ui()` falls back to `atty::is(Stdout)` for TTY detection. In a local terminal this returns `true`, resulting in `UI::Tui` → `use_pty = true`.

With PTY enabled:
- **`\r\n`**: PTY line discipline converts `\n` to `\r\n`
- **`\u{4}`**: EOT (End of Transmission) character emitted when the PTY write end is closed

In CI, stdout is a pipe so TTY is not detected and the issue does not occur.

## Fix

Add a `use_pty: Option<bool>` parameter to `Workspace::new`.

- `Some(true/false)` — explicitly control PTY usage (tests pass `Some(false)`)
- `None` — infer from `root_config.ui` as before (used in `cli.rs` for normal execution)

This ensures PTY is always disabled in tests while preserving the existing behavior for normal execution.

## Test plan
- [x] `cargo test test_watch` passes in a local terminal
- [x] All 21 tests pass with `cargo test`