### PR TITLE
feat(config): add finalized_by task option

### DIFF
--- a/docs/schema-body.md
+++ b/docs/schema-body.md
@@ -203,6 +203,13 @@ working_dir: src
 - **Template:** yes
 - **Description:** Dotenv files
 
+### finalized_by
+
+- **Type:** <code>Array&lt;<a href="#finalizedbyconfig">FinalizedByConfig</a>&gt;</code>
+- **Required:** no
+- **Default:** `[]`
+- **Description:** Finalizer tasks
+
 ### inputs
 
 - **Type:** <code>Array&lt;string&gt;</code>
@@ -389,6 +396,28 @@ Probe failure during that period will not be counted towards the maximum number 
 - **Template:** yes
 - **Description:** Working directory
 
+## FinalizedByConfig
+
+- **Type:** <code>string | <a href="#finalizedbyconfigstruct">FinalizedByConfigStruct</a></code>
+- **Template:** yes
+
+## FinalizedByConfigStruct
+
+### task
+
+- **Type:** <code>string</code>
+- **Required:** yes
+- **Template:** yes
+- **Description:** Finalizer task name
+
+### vars
+
+- **Type:** <code>Map&lt;string, <a href="#varsconfig">VarsConfig</a>&gt;</code>
+- **Required:** no
+- **Default:** `{}`
+- **Template:** yes
+- **Description:** Variables to override the finalizer task vars.
+
 ## HealthCheckConfig
 
 - **Type:** <code><a href="#logprobeconfig">LogProbeConfig</a> | <a href="#execprobeconfig">ExecProbeConfig</a></code>
@@ -507,6 +536,24 @@ Probe failure during that period will not be counted towards the maximum number 
 - **Default:** `[]`
 - **Template:** yes
 - **Description:** Dotenv files. Merged with the project `env_files`.
+
+### finalized_by
+
+- **Type:** <code>Array&lt;<a href="#finalizedbyconfig">FinalizedByConfig</a>&gt;</code>
+- **Required:** no
+- **Default:** `[]`
+- **Description:** Finalizer tasks that run after this task completes, regardless of success or failure.
+Similar to Gradle's `finalizedBy`.
+```yaml
+tasks:
+  build:
+    command: cargo build
+    finalized_by:
+      - cleanup
+      - task: report
+        vars:
+          output_dir: dist
+```
 
 ### inputs
 

--- a/docs/schema-body.md
+++ b/docs/schema-body.md
@@ -544,6 +544,8 @@ Probe failure during that period will not be counted towards the maximum number 
 - **Default:** `[]`
 - **Description:** Finalizer tasks that run after this task completes, regardless of success or failure.
 Similar to Gradle's `finalizedBy`.
+Supports templating for `finalized_by`, including nested `finalized_by.task`
+and `finalized_by.vars`.
 ```yaml
 tasks:
   build:

--- a/schema.json
+++ b/schema.json
@@ -153,6 +153,15 @@
           },
           "x-template": true
         },
+        "finalized_by": {
+          "description": "Finalizer tasks",
+          "type": "array",
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/FinalizedByConfig"
+          },
+          "x-template": true
+        },
         "inputs": {
           "description": "Inputs file glob patterns",
           "type": "array",
@@ -387,6 +396,39 @@
         "command"
       ]
     },
+    "FinalizedByConfig": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/FinalizedByConfigStruct"
+        }
+      ],
+      "x-template": true
+    },
+    "FinalizedByConfigStruct": {
+      "type": "object",
+      "properties": {
+        "task": {
+          "description": "Finalizer task name",
+          "type": "string",
+          "x-template": true
+        },
+        "vars": {
+          "description": "Variables to override the finalizer task vars.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/VarsConfig"
+          },
+          "default": {},
+          "x-template": true
+        }
+      },
+      "required": [
+        "task"
+      ]
+    },
     "HealthCheckConfig": {
       "anyOf": [
         {
@@ -543,6 +585,15 @@
           "default": [],
           "items": {
             "type": "string"
+          },
+          "x-template": true
+        },
+        "finalized_by": {
+          "description": "Finalizer tasks that run after this task completes, regardless of success or failure.\nSimilar to Gradle's `finalizedBy`.\n```yaml\ntasks:\n  build:\n    command: cargo build\n    finalized_by:\n      - cleanup\n      - task: report\n        vars:\n          output_dir: dist\n```",
+          "type": "array",
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/FinalizedByConfig"
           },
           "x-template": true
         },

--- a/schema.json
+++ b/schema.json
@@ -589,7 +589,7 @@
           "x-template": true
         },
         "finalized_by": {
-          "description": "Finalizer tasks that run after this task completes, regardless of success or failure.\nSimilar to Gradle's `finalizedBy`.\n```yaml\ntasks:\n  build:\n    command: cargo build\n    finalized_by:\n      - cleanup\n      - task: report\n        vars:\n          output_dir: dist\n```",
+          "description": "Finalizer tasks that run after this task completes, regardless of success or failure.\nSimilar to Gradle's `finalizedBy`.\nSupports templating for `finalized_by`, including nested `finalized_by.task`\nand `finalized_by.vars`.\n```yaml\ntasks:\n  build:\n    command: cargo build\n    finalized_by:\n      - cleanup\n      - task: report\n        vars:\n          output_dir: dist\n```",
           "type": "array",
           "default": [],
           "items": {

--- a/src/config.rs
+++ b/src/config.rs
@@ -281,6 +281,14 @@ impl ProjectConfig {
                     anyhow::bail!("tasks.{}.depends_on: task {:?} is not defined.", t.name, d);
                 }
             }
+            for f in t.finalized_by.iter().map(|f| match f {
+                FinalizedByConfig::String(s) => s.clone(),
+                FinalizedByConfig::Struct(s) => s.task.clone(),
+            }) {
+                if !tasks.contains(&f) {
+                    anyhow::bail!("tasks.{}.finalized_by: task {:?} is not defined.", t.name, f);
+                }
+            }
         }
         Ok(())
     }
@@ -309,6 +317,17 @@ impl ProjectConfig {
                         task: Task::qualified_name(&data.name, &s.task),
                         vars: s.vars.clone(),
                         cascade: s.cascade,
+                    }),
+                })
+                .collect();
+            v.finalized_by = v
+                .finalized_by
+                .iter()
+                .map(|f| match f {
+                    FinalizedByConfig::String(s) => FinalizedByConfig::String(Task::qualified_name(&name, s)),
+                    FinalizedByConfig::Struct(s) => FinalizedByConfig::Struct(FinalizedByConfigStruct {
+                        task: Task::qualified_name(&data.name, &s.task),
+                        vars: s.vars.clone(),
                     }),
                 })
                 .collect();
@@ -470,21 +489,31 @@ impl ProjectConfig {
             .iter()
             .map(|d| {
                 if let Some(TaskSelector::Regex(ref pattern)) = d.tasks {
-                    Regex::new(pattern)
-                        .with_context(|| format!("defaults: invalid regex pattern {:?}", pattern))?;
+                    Regex::new(pattern).with_context(|| format!("defaults: invalid regex pattern {:?}", pattern))?;
                 }
                 Ok(DefaultsConfig {
                     depends_on: d
                         .depends_on
                         .iter()
                         .map(|dep| match dep {
-                            DependsOnConfig::String(s) => {
-                                DependsOnConfig::String(Task::qualified_name(&self.name, s))
-                            }
+                            DependsOnConfig::String(s) => DependsOnConfig::String(Task::qualified_name(&self.name, s)),
                             DependsOnConfig::Struct(s) => DependsOnConfig::Struct(DependsOnConfigStruct {
                                 task: Task::qualified_name(&self.name, &s.task),
                                 vars: s.vars.clone(),
                                 cascade: s.cascade,
+                            }),
+                        })
+                        .collect(),
+                    finalized_by: d
+                        .finalized_by
+                        .iter()
+                        .map(|f| match f {
+                            FinalizedByConfig::String(s) => {
+                                FinalizedByConfig::String(Task::qualified_name(&self.name, s))
+                            }
+                            FinalizedByConfig::Struct(s) => FinalizedByConfig::Struct(FinalizedByConfigStruct {
+                                task: Task::qualified_name(&self.name, &s.task),
+                                vars: s.vars.clone(),
                             }),
                         })
                         .collect(),
@@ -502,6 +531,7 @@ impl ProjectConfig {
             let mut eff_env: IndexMap<String, String> = IndexMap::new();
             let mut eff_env_files: Vec<String> = Vec::new();
             let mut eff_depends_on: Vec<DependsOnConfig> = Vec::new();
+            let mut eff_finalized_by: Vec<FinalizedByConfig> = Vec::new();
             let mut eff_inputs: Vec<String> = Vec::new();
             let mut eff_outputs: Vec<String> = Vec::new();
             let mut matched = false;
@@ -532,6 +562,7 @@ impl ProjectConfig {
                 // Arrays: concatenate in order
                 eff_env_files.extend(default.env_files.clone());
                 eff_depends_on.extend(default.depends_on.clone());
+                eff_finalized_by.extend(default.finalized_by.clone());
                 eff_inputs.extend(default.inputs.clone());
                 eff_outputs.extend(default.outputs.clone());
             }
@@ -562,6 +593,9 @@ impl ProjectConfig {
 
             eff_depends_on.append(&mut task_config.depends_on);
             task_config.depends_on = eff_depends_on;
+
+            eff_finalized_by.append(&mut task_config.finalized_by);
+            task_config.finalized_by = eff_finalized_by;
 
             eff_inputs.append(&mut task_config.inputs);
             task_config.inputs = eff_inputs;
@@ -631,6 +665,22 @@ pub struct TaskConfig {
     #[schemars(extend("x-template" = true))]
     pub depends_on: Vec<DependsOnConfig>,
 
+    /// Finalizer tasks that run after this task completes, regardless of success or failure.
+    /// Similar to Gradle's `finalizedBy`.
+    /// ```yaml
+    /// tasks:
+    ///   build:
+    ///     command: cargo build
+    ///     finalized_by:
+    ///       - cleanup
+    ///       - task: report
+    ///         vars:
+    ///           output_dir: dist
+    /// ```
+    #[serde(default)]
+    #[schemars(extend("x-template" = true))]
+    pub finalized_by: Vec<FinalizedByConfig>,
+
     /// Service configurations
     pub service: Option<ServiceConfig>,
 
@@ -670,7 +720,6 @@ impl TaskConfig {
     pub fn output_paths(&self, dir: &PathBuf) -> Vec<PathBuf> {
         self.outputs.iter().map(|f| absolute_or_join(f, dir)).collect()
     }
-
 }
 
 fn absolute_or_join(path: &str, dir: &Path) -> PathBuf {
@@ -786,6 +835,26 @@ pub struct DependsOnConfigStruct {
 
 fn default_cascade() -> bool {
     true
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(untagged)]
+#[schemars(extend("x-template" = true))]
+pub enum FinalizedByConfig {
+    String(String),
+    Struct(FinalizedByConfigStruct),
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct FinalizedByConfigStruct {
+    /// Finalizer task name
+    #[schemars(extend("x-template" = true))]
+    pub task: String,
+
+    /// Variables to override the finalizer task vars.
+    #[serde(default)]
+    #[schemars(extend("x-template" = true))]
+    pub vars: IndexMap<String, VarsConfig>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
@@ -1096,6 +1165,11 @@ pub struct DefaultsConfig {
     #[serde(default)]
     #[schemars(extend("x-template" = true))]
     pub depends_on: Vec<DependsOnConfig>,
+
+    /// Finalizer tasks
+    #[serde(default)]
+    #[schemars(extend("x-template" = true))]
+    pub finalized_by: Vec<FinalizedByConfig>,
 
     /// Service configurations
     pub service: Option<ServiceConfig>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -314,7 +314,7 @@ impl ProjectConfig {
                 .map(|d| match d {
                     DependsOnConfig::String(s) => DependsOnConfig::String(Task::qualified_name(&name, s)),
                     DependsOnConfig::Struct(s) => DependsOnConfig::Struct(DependsOnConfigStruct {
-                        task: Task::qualified_name(&data.name, &s.task),
+                        task: Task::qualified_name(&name, &s.task),
                         vars: s.vars.clone(),
                         cascade: s.cascade,
                     }),
@@ -326,7 +326,7 @@ impl ProjectConfig {
                 .map(|f| match f {
                     FinalizedByConfig::String(s) => FinalizedByConfig::String(Task::qualified_name(&name, s)),
                     FinalizedByConfig::Struct(s) => FinalizedByConfig::Struct(FinalizedByConfigStruct {
-                        task: Task::qualified_name(&data.name, &s.task),
+                        task: Task::qualified_name(&name, &s.task),
                         vars: s.vars.clone(),
                     }),
                 })

--- a/src/config.rs
+++ b/src/config.rs
@@ -667,6 +667,8 @@ pub struct TaskConfig {
 
     /// Finalizer tasks that run after this task completes, regardless of success or failure.
     /// Similar to Gradle's `finalizedBy`.
+    /// Supports templating for `finalized_by`, including nested `finalized_by.task`
+    /// and `finalized_by.vars`.
     /// ```yaml
     /// tasks:
     ///   build:

--- a/src/project.rs
+++ b/src/project.rs
@@ -1,5 +1,6 @@
 use crate::config::{
-    DependsOnConfig, HealthCheckConfig, ProjectConfig, Restart, ServiceConfig, TaskConfig, VarsConfig, UI,
+    DependsOnConfig, FinalizedByConfig, HealthCheckConfig, ProjectConfig, Restart, ServiceConfig, TaskConfig,
+    VarsConfig, UI,
 };
 use crate::probe::{ExecProbe, LogLineProbe, Probe};
 use crate::template::ConfigRenderer;
@@ -216,6 +217,10 @@ pub struct Task {
 
     /// Dependency task names
     pub depends_on: Vec<DependsOn>,
+
+    /// Finalizer task names.
+    /// These tasks run after this task completes, regardless of success/failure.
+    pub finalized_by: Vec<String>,
 
     /// Task working directory path (absolute).
     pub working_dir: PathBuf,
@@ -440,6 +445,15 @@ impl Task {
                     },
                 })
                 .filter(|d| d.task != task_name) // Exclude the task itself
+                .collect(),
+            finalized_by: task_config
+                .finalized_by
+                .iter()
+                .map(|f| match f {
+                    FinalizedByConfig::String(s) => Task::qualified_name(project_name, s),
+                    FinalizedByConfig::Struct(s) => Task::qualified_name(project_name, &s.task),
+                })
+                .filter(|f| *f != task_name)
                 .collect(),
             is_service,
             probe,

--- a/src/runner/graph.rs
+++ b/src/runner/graph.rs
@@ -412,20 +412,24 @@ impl TaskGraph {
                     Control::<()>::Continue
                 });
 
-                // Also include finalizer tasks and their transitive dependencies
-                let mut finalizer_indices = Vec::new();
-                for &idx in &visited {
-                    if let Some(task) = self.graph.node_weight(idx) {
-                        for f in &task.finalized_by {
-                            if let Some((_, fi)) = self.node_by_task(f) {
-                                if !visited.contains(&fi) {
-                                    finalizer_indices.push(fi);
+                // Also include finalizer tasks and their transitive dependencies.
+                // Loop until no new finalizer nodes are discovered (handles chained finalizers).
+                loop {
+                    let mut finalizer_indices = Vec::new();
+                    for &idx in &visited {
+                        if let Some(task) = self.graph.node_weight(idx) {
+                            for f in &task.finalized_by {
+                                if let Some((_, fi)) = self.node_by_task(f) {
+                                    if !visited.contains(&fi) {
+                                        finalizer_indices.push(fi);
+                                    }
                                 }
                             }
                         }
                     }
-                }
-                if !finalizer_indices.is_empty() {
+                    if finalizer_indices.is_empty() {
+                        break;
+                    }
                     depth_first_search(&self.graph, finalizer_indices, |idx| {
                         if let petgraph::visit::DfsEvent::Discover(n, _) = idx {
                             visited.insert(n);

--- a/src/runner/graph.rs
+++ b/src/runner/graph.rs
@@ -25,7 +25,7 @@ pub struct EdgeInfo {
 #[derive(Clone)]
 pub struct TaskGraph {
     graph: DiGraph<Task, EdgeInfo>,
-    targets: Vec<String>,
+    targets: HashSet<String>,
 }
 
 pub struct VisitorMessage {
@@ -145,14 +145,15 @@ impl TaskGraph {
         // If targets are not given, consider all tasks as target
         let mut targets = targets
             .cloned()
-            .unwrap_or_else(|| tasks.iter().map(|t| t.name.clone()).collect::<Vec<_>>());
+            .unwrap_or_else(|| tasks.iter().map(|t| t.name.clone()).collect())
+            .into_iter().collect::<HashSet<_>>();
 
         // Expand targets to include finalizer tasks so quit_on_done waits for them
         for t in tasks {
             if targets.contains(&t.name) {
                 for f in &t.finalized_by {
                     if !targets.contains(f) {
-                        targets.push(f.clone());
+                        targets.insert(f.clone());
                     }
                 }
             }
@@ -193,7 +194,7 @@ impl TaskGraph {
         let (visitor_tx, visitor_rx) = broadcast::channel(1024);
 
         // Remaining target tasks
-        let targets_remaining: HashSet<String> = self.targets.iter().map(|s| s.clone()).collect();
+        let targets_remaining: HashSet<String> = self.targets.clone();
         let targets_remaining = Arc::new(Mutex::new(targets_remaining));
 
         // Run visitor thread for all nodes
@@ -405,7 +406,7 @@ impl TaskGraph {
         })
     }
 
-    pub fn targets(&self) -> &Vec<String> {
+    pub fn targets(&self) -> &HashSet<String> {
         &self.targets
     }
 

--- a/src/runner/graph.rs
+++ b/src/runner/graph.rs
@@ -394,6 +394,10 @@ impl TaskGraph {
         })
     }
 
+    pub fn set_targets(&mut self, targets: Vec<String>) {
+        self.targets = targets;
+    }
+
     pub fn transitive_closure(&self, names: &Vec<String>, direction: Direction) -> anyhow::Result<TaskGraph> {
         let mut visited = IndexSet::<NodeIndex>::new();
 

--- a/src/runner/graph.rs
+++ b/src/runner/graph.rs
@@ -199,7 +199,7 @@ impl TaskGraph {
                 .clone()
                 .map(|n| self.graph.node_weight(n).cloned().context("node not found"))
                 .collect::<anyhow::Result<Vec<_>>>()?;
-            // Watch channels to receive the result of dependent tasks, with finalizer flag
+            // Watch channels to receive the results of dependency tasks, with finalizer flag
             let dep_rxs: Vec<(watch::Receiver<NodeResult>, bool)> = neighbors
                 .clone()
                 .map(|n| {

--- a/src/runner/graph.rs
+++ b/src/runner/graph.rs
@@ -15,9 +15,15 @@ use tokio::sync::{broadcast, mpsc, watch};
 use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
+#[derive(Debug, Clone)]
+pub struct EdgeInfo {
+    pub cascade: bool,
+    pub is_finalizer: bool,
+}
+
 #[derive(Clone)]
 pub struct TaskGraph {
-    graph: DiGraph<Task, bool>,
+    graph: DiGraph<Task, EdgeInfo>,
     targets: Vec<String>,
 }
 
@@ -68,7 +74,7 @@ impl NodeResult {
 
 impl TaskGraph {
     pub fn new(tasks: &Vec<Task>, targets: Option<&Vec<String>>, force: bool) -> anyhow::Result<TaskGraph> {
-        let mut graph = DiGraph::<Task, bool>::new();
+        let mut graph = DiGraph::<Task, EdgeInfo>::new();
         let mut nodes = HashMap::new();
 
         // If `force` is true, we only add the target tasks as nodes to the graph
@@ -96,12 +102,40 @@ impl TaskGraph {
                 let to = nodes.get(&d.task);
                 match (from, to) {
                     (Some(from), Some(to)) => {
-                        graph.add_edge(*from, *to, d.cascade);
+                        graph.add_edge(
+                            *from,
+                            *to,
+                            EdgeInfo {
+                                cascade: d.cascade,
+                                is_finalizer: false,
+                            },
+                        );
                     }
                     // Ignore if the dependent task does not exist.
                     // This can occur when creating a subgraph by `transitive_closure`.
                     _ => {
                         warn!("Cannot find node for task {} and dependency {}", t.name, d.task);
+                    }
+                }
+            }
+
+            // Add finalized_by edges: finalizer depends on the finalized task
+            for f in &t.finalized_by {
+                let finalizer_idx = nodes.get(f);
+                let finalized_idx = nodes.get(&t.name);
+                match (finalizer_idx, finalized_idx) {
+                    (Some(fi), Some(fd)) => {
+                        graph.add_edge(
+                            *fi,
+                            *fd,
+                            EdgeInfo {
+                                cascade: false,
+                                is_finalizer: true,
+                            },
+                        );
+                    }
+                    _ => {
+                        warn!("Cannot find node for task {} and finalizer {}", t.name, f);
                     }
                 }
             }
@@ -164,10 +198,15 @@ impl TaskGraph {
                 .clone()
                 .map(|n| self.graph.node_weight(n).cloned().context("node not found"))
                 .collect::<anyhow::Result<Vec<_>>>()?;
-            // Watch channels to receive the result of dependent tasks
-            let dep_rxs = neighbors
+            // Watch channels to receive the result of dependent tasks, with finalizer flag
+            let dep_rxs: Vec<(watch::Receiver<NodeResult>, bool)> = neighbors
                 .clone()
-                .map(|n| rxs.get(&n).cloned().context("sender not found"))
+                .map(|n| {
+                    let rx = rxs.get(&n).cloned().context("sender not found")?;
+                    // Check if ALL edges from this node to the neighbor are finalizer edges
+                    let all_finalizer = self.graph.edges_connecting(node_id, n).all(|e| e.weight().is_finalizer);
+                    Ok((rx, all_finalizer))
+                })
                 .collect::<anyhow::Result<Vec<_>>>()?;
 
             let task_name = task.name.clone();
@@ -356,12 +395,6 @@ impl TaskGraph {
 
     pub fn transitive_closure(&self, names: &Vec<String>, direction: Direction) -> anyhow::Result<TaskGraph> {
         let mut visited = Vec::<NodeIndex>::new();
-        let mut visitor = |idx| {
-            if let petgraph::visit::DfsEvent::Discover(n, _) = idx {
-                visited.push(n);
-            }
-            Control::<()>::Continue
-        };
 
         let indices = names
             .iter()
@@ -371,24 +404,59 @@ impl TaskGraph {
 
         match direction {
             Direction::Outgoing => {
-                depth_first_search(&self.graph, indices, visitor);
+                depth_first_search(&self.graph, indices, |idx| {
+                    if let petgraph::visit::DfsEvent::Discover(n, _) = idx {
+                        visited.push(n);
+                    }
+                    Control::<()>::Continue
+                });
+
+                // Also include finalizer tasks and their transitive dependencies
+                let visited_set: HashSet<NodeIndex> = visited.iter().cloned().collect();
+                let mut finalizer_indices = Vec::new();
+                for &idx in &visited {
+                    if let Some(task) = self.graph.node_weight(idx) {
+                        for f in &task.finalized_by {
+                            if let Some((_, fi)) = self.node_by_task(f) {
+                                if !visited_set.contains(&fi) {
+                                    finalizer_indices.push(fi);
+                                }
+                            }
+                        }
+                    }
+                }
+                if !finalizer_indices.is_empty() {
+                    depth_first_search(&self.graph, finalizer_indices, |idx| {
+                        if let petgraph::visit::DfsEvent::Discover(n, _) = idx {
+                            visited.push(n);
+                        }
+                        Control::<()>::Continue
+                    });
+                }
             }
             Direction::Incoming => {
                 depth_first_search(Reversed(&self.graph), indices, |event| {
+                    if let petgraph::visit::DfsEvent::Discover(n, _) = event {
+                        visited.push(n);
+                    }
                     if let petgraph::visit::DfsEvent::TreeEdge(u, v) = event {
                         if let Ok(edge_idx) = self.graph.find_edge(v, u).context("edge not found") {
-                            if let Some(cascade) = self.graph.edge_weight(edge_idx) {
-                                if !cascade {
+                            if let Some(edge_info) = self.graph.edge_weight(edge_idx) {
+                                if !edge_info.cascade {
                                     return Control::Prune;
                                 }
                             }
                         }
                         return Control::Continue;
                     }
-                    visitor(event)
+                    Control::<()>::Continue
                 });
             }
         };
+
+        // Deduplicate visited nodes (finalizer DFS may revisit nodes)
+        let mut seen = HashSet::new();
+        visited.retain(|idx| seen.insert(*idx));
 
         let tasks = visited
             .iter()
@@ -412,11 +480,10 @@ impl TaskGraph {
         None
     }
 
-    async fn wait_all_watches(mut receivers: Vec<watch::Receiver<NodeResult>>) -> anyhow::Result<bool> {
-        for rx in receivers.iter_mut() {
-            let v = rx.borrow().clone();
+    async fn wait_all_watches(receivers: Vec<(watch::Receiver<NodeResult>, bool)>) -> anyhow::Result<bool> {
+        for (mut rx, is_finalizer) in receivers {
             if (*rx.borrow()).present() {
-                if !(*rx.borrow()).success() {
+                if !(*rx.borrow()).success() && !is_finalizer {
                     return Ok(false);
                 }
                 continue;
@@ -426,7 +493,7 @@ impl TaskGraph {
                     anyhow::bail!("watch channel closed");
                 }
                 if (*rx.borrow()).present() {
-                    if !(*rx.borrow()).success() {
+                    if !(*rx.borrow()).success() && !is_finalizer {
                         return Ok(false);
                     }
                     break;

--- a/src/runner/graph.rs
+++ b/src/runner/graph.rs
@@ -2,6 +2,7 @@ use crate::project::Task;
 use crate::tokio_spawn;
 use anyhow::Context;
 use futures::stream::FuturesUnordered;
+use indexmap::IndexSet;
 use petgraph::algo::toposort;
 use petgraph::dot::{Config, Dot};
 use petgraph::graph::{DiGraph, NodeIndex};
@@ -394,7 +395,7 @@ impl TaskGraph {
     }
 
     pub fn transitive_closure(&self, names: &Vec<String>, direction: Direction) -> anyhow::Result<TaskGraph> {
-        let mut visited = Vec::<NodeIndex>::new();
+        let mut visited = IndexSet::<NodeIndex>::new();
 
         let indices = names
             .iter()
@@ -406,19 +407,18 @@ impl TaskGraph {
             Direction::Outgoing => {
                 depth_first_search(&self.graph, indices, |idx| {
                     if let petgraph::visit::DfsEvent::Discover(n, _) = idx {
-                        visited.push(n);
+                        visited.insert(n);
                     }
                     Control::<()>::Continue
                 });
 
                 // Also include finalizer tasks and their transitive dependencies
-                let visited_set: HashSet<NodeIndex> = visited.iter().cloned().collect();
                 let mut finalizer_indices = Vec::new();
                 for &idx in &visited {
                     if let Some(task) = self.graph.node_weight(idx) {
                         for f in &task.finalized_by {
                             if let Some((_, fi)) = self.node_by_task(f) {
-                                if !visited_set.contains(&fi) {
+                                if !visited.contains(&fi) {
                                     finalizer_indices.push(fi);
                                 }
                             }
@@ -428,7 +428,7 @@ impl TaskGraph {
                 if !finalizer_indices.is_empty() {
                     depth_first_search(&self.graph, finalizer_indices, |idx| {
                         if let petgraph::visit::DfsEvent::Discover(n, _) = idx {
-                            visited.push(n);
+                            visited.insert(n);
                         }
                         Control::<()>::Continue
                     });
@@ -437,7 +437,7 @@ impl TaskGraph {
             Direction::Incoming => {
                 depth_first_search(Reversed(&self.graph), indices, |event| {
                     if let petgraph::visit::DfsEvent::Discover(n, _) = event {
-                        visited.push(n);
+                        visited.insert(n);
                     }
                     if let petgraph::visit::DfsEvent::TreeEdge(u, v) = event {
                         if let Ok(edge_idx) = self.graph.find_edge(v, u).context("edge not found") {
@@ -453,10 +453,6 @@ impl TaskGraph {
                 });
             }
         };
-
-        // Deduplicate visited nodes (finalizer DFS may revisit nodes)
-        let mut seen = HashSet::new();
-        visited.retain(|idx| seen.insert(*idx));
 
         let tasks = visited
             .iter()

--- a/src/runner/graph.rs
+++ b/src/runner/graph.rs
@@ -143,9 +143,20 @@ impl TaskGraph {
         }
 
         // If targets are not given, consider all tasks as target
-        let targets = targets
+        let mut targets = targets
             .cloned()
-            .unwrap_or_else(|| tasks.iter().map(|t| t.name.clone()).collect());
+            .unwrap_or_else(|| tasks.iter().map(|t| t.name.clone()).collect::<Vec<_>>());
+
+        // Expand targets to include finalizer tasks so quit_on_done waits for them
+        for t in tasks {
+            if targets.contains(&t.name) {
+                for f in &t.finalized_by {
+                    if !targets.contains(f) {
+                        targets.push(f.clone());
+                    }
+                }
+            }
+        }
 
         let ret = TaskGraph { graph, targets };
 
@@ -394,8 +405,8 @@ impl TaskGraph {
         })
     }
 
-    pub fn set_targets(&mut self, targets: Vec<String>) {
-        self.targets = targets;
+    pub fn targets(&self) -> &Vec<String> {
+        &self.targets
     }
 
     pub fn transitive_closure(&self, names: &Vec<String>, direction: Direction) -> anyhow::Result<TaskGraph> {

--- a/src/runner/graph.rs
+++ b/src/runner/graph.rs
@@ -479,7 +479,7 @@ impl TaskGraph {
     async fn wait_all_watches(receivers: Vec<(watch::Receiver<NodeResult>, bool)>) -> anyhow::Result<bool> {
         for (mut rx, ignore_failure) in receivers {
             if (*rx.borrow()).present() {
-                if *rx.borrow().success() || ignore_failure {
+                if (*rx.borrow()).success() || ignore_failure {
                     continue;
                 }
                 return Ok(false);
@@ -489,7 +489,7 @@ impl TaskGraph {
                     anyhow::bail!("watch channel closed");
                 }
                 if (*rx.borrow()).present() {
-                    if *rx.borrow().success() || ignore_failure {
+                    if (*rx.borrow()).success() || ignore_failure {
                         break;
                     }
                     return Ok(false);

--- a/src/runner/graph.rs
+++ b/src/runner/graph.rs
@@ -205,8 +205,8 @@ impl TaskGraph {
                 .map(|n| {
                     let rx = rxs.get(&n).cloned().context("sender not found")?;
                     // Check if ALL edges from this node to the neighbor are finalizer edges
-                    let all_finalizer = self.graph.edges_connecting(node_id, n).all(|e| e.weight().is_finalizer);
-                    Ok((rx, all_finalizer))
+                    let ignore_failure = self.graph.edges_connecting(node_id, n).all(|e| e.weight().is_finalizer);
+                    Ok((rx, ignore_failure))
                 })
                 .collect::<anyhow::Result<Vec<_>>>()?;
 
@@ -477,22 +477,22 @@ impl TaskGraph {
     }
 
     async fn wait_all_watches(receivers: Vec<(watch::Receiver<NodeResult>, bool)>) -> anyhow::Result<bool> {
-        for (mut rx, is_finalizer) in receivers {
+        for (mut rx, ignore_failure) in receivers {
             if (*rx.borrow()).present() {
-                if !(*rx.borrow()).success() && !is_finalizer {
-                    return Ok(false);
+                if *rx.borrow().success() || ignore_failure {
+                    continue;
                 }
-                continue;
+                return Ok(false);
             }
             loop {
                 if rx.changed().await.is_err() {
                     anyhow::bail!("watch channel closed");
                 }
                 if (*rx.borrow()).present() {
-                    if !(*rx.borrow()).success() && !is_finalizer {
-                        return Ok(false);
+                    if *rx.borrow().success() || ignore_failure {
+                        break;
                     }
-                    break;
+                    return Ok(false);
                 }
             }
         }

--- a/src/runner/graph.rs
+++ b/src/runner/graph.rs
@@ -149,9 +149,7 @@ impl TaskGraph {
         for t in tasks {
             if targets.contains(&t.name) {
                 for f in &t.finalized_by {
-                    if !targets.contains(f) {
-                        targets.insert(f.clone());
-                    }
+                    targets.insert(f.clone());
                 }
             }
         }

--- a/src/runner/graph.rs
+++ b/src/runner/graph.rs
@@ -19,7 +19,6 @@ use tracing::{debug, info, warn};
 #[derive(Debug, Clone)]
 pub struct EdgeInfo {
     pub cascade: bool,
-    pub is_finalizer: bool,
 }
 
 #[derive(Clone)]
@@ -108,7 +107,6 @@ impl TaskGraph {
                             *to,
                             EdgeInfo {
                                 cascade: d.cascade,
-                                is_finalizer: false,
                             },
                         );
                     }
@@ -131,7 +129,6 @@ impl TaskGraph {
                             *fd,
                             EdgeInfo {
                                 cascade: false,
-                                is_finalizer: true,
                             },
                         );
                     }
@@ -211,13 +208,16 @@ impl TaskGraph {
                 .clone()
                 .map(|n| self.graph.node_weight(n).cloned().context("node not found"))
                 .collect::<anyhow::Result<Vec<_>>>()?;
-            // Watch channels to receive the results of dependency tasks, with finalizer flag
+            // Watch channels to receive the results of dependency tasks, with finalizer flag.
+            // A neighbor not listed in task.depends_on is a finalized task (reverse edge),
+            // so failures from it should be ignored (finalizer runs regardless).
+            let dep_names: HashSet<&str> = task.depends_on.iter().map(|d| d.task.as_str()).collect();
             let dep_rxs: Vec<(watch::Receiver<NodeResult>, bool)> = neighbors
                 .clone()
                 .map(|n| {
                     let rx = rxs.get(&n).cloned().context("sender not found")?;
-                    // Check if ALL edges from this node to the neighbor are finalizer edges
-                    let ignore_failure = self.graph.edges_connecting(node_id, n).all(|e| e.weight().is_finalizer);
+                    let neighbor_name = self.graph.node_weight(n).context("node not found")?.name.as_str();
+                    let ignore_failure = !dep_names.contains(neighbor_name);
                     Ok((rx, ignore_failure))
                 })
                 .collect::<anyhow::Result<Vec<_>>>()?;

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -50,7 +50,7 @@ impl TaskRunner {
         let target_tasks = ws.target_tasks.clone();
 
         let task_graph_all = TaskGraph::new(&all_tasks, Some(&target_tasks), ws.force)?;
-        let task_graph = task_graph_all.transitive_closure(&target_tasks, Direction::Outgoing)?;
+        let mut task_graph = task_graph_all.transitive_closure(&target_tasks, Direction::Outgoing)?;
         let tasks = task_graph.sort()?;
 
         // Expand target_tasks to include finalizer tasks so quit_on_done waits for them
@@ -62,6 +62,9 @@ impl TaskRunner {
                 }
             }
         }
+
+        // Update task graph targets so visit()'s quit_on_done also waits for finalizers
+        task_graph.set_targets(target_tasks.clone());
 
         debug!("Task graph:\n{:?}", task_graph);
 

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -125,7 +125,7 @@ impl TaskRunner {
 
         // Task futures
         let mut task_fut = FuturesUnordered::new();
-        let targets_remaining: HashSet<String> = self.task_graph.targets().iter().cloned().collect();
+        let targets_remaining = self.task_graph.targets().clone();
         let targets_remaining = Arc::new(Mutex::new(targets_remaining));
 
         while !node_rx.is_closed() {

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -50,21 +50,8 @@ impl TaskRunner {
         let target_tasks = ws.target_tasks.clone();
 
         let task_graph_all = TaskGraph::new(&all_tasks, Some(&target_tasks), ws.force)?;
-        let mut task_graph = task_graph_all.transitive_closure(&target_tasks, Direction::Outgoing)?;
+        let task_graph = task_graph_all.transitive_closure(&target_tasks, Direction::Outgoing)?;
         let tasks = task_graph.sort()?;
-
-        // Expand target_tasks to include finalizer tasks so quit_on_done waits for them
-        let mut target_tasks = target_tasks;
-        for task in &tasks {
-            for f in &task.finalized_by {
-                if !target_tasks.contains(f) {
-                    target_tasks.push(f.clone());
-                }
-            }
-        }
-
-        // Update task graph targets so visit()'s quit_on_done also waits for finalizers
-        task_graph.set_targets(target_tasks.clone());
 
         debug!("Task graph:\n{:?}", task_graph);
 
@@ -138,7 +125,7 @@ impl TaskRunner {
 
         // Task futures
         let mut task_fut = FuturesUnordered::new();
-        let targets_remaining: HashSet<String> = self.target_tasks.iter().map(|s| s.clone()).collect();
+        let targets_remaining: HashSet<String> = self.task_graph.targets().iter().cloned().collect();
         let targets_remaining = Arc::new(Mutex::new(targets_remaining));
 
         while !node_rx.is_closed() {

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -52,6 +52,17 @@ impl TaskRunner {
         let task_graph_all = TaskGraph::new(&all_tasks, Some(&target_tasks), ws.force)?;
         let task_graph = task_graph_all.transitive_closure(&target_tasks, Direction::Outgoing)?;
         let tasks = task_graph.sort()?;
+
+        // Expand target_tasks to include finalizer tasks so quit_on_done waits for them
+        let mut target_tasks = target_tasks;
+        for task in &tasks {
+            for f in &task.finalized_by {
+                if !target_tasks.contains(f) {
+                    target_tasks.push(f.clone());
+                }
+            }
+        }
+
         debug!("Task graph:\n{:?}", task_graph);
 
         let file_watcher = if ws.watch {

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,6 +1,6 @@
 use crate::config::{
-    DependsOnConfig, DependsOnConfigStruct, DynamicVarsInner, HealthCheckConfig, ProjectConfig, ServiceConfig,
-    TaskConfig, VarsConfig,
+    DependsOnConfig, DependsOnConfigStruct, DynamicVarsInner, FinalizedByConfig, FinalizedByConfigStruct,
+    HealthCheckConfig, ProjectConfig, ServiceConfig, TaskConfig, VarsConfig,
 };
 use crate::log::OutputCollector;
 use crate::process::{ChildExit, Command, ProcessManager};
@@ -257,6 +257,27 @@ impl TaskConfig {
             }
         }
         config.depends_on = rendered_depends_on;
+
+        // Render finalized_by task and vars
+        let mut rendered_finalized_by = Vec::new();
+        for finalized_by in config.finalized_by.iter() {
+            match finalized_by {
+                FinalizedByConfig::String(task) => {
+                    let task = tera.render_str(task, &context)?;
+                    if !task.ends_with("#") {
+                        rendered_finalized_by.push(FinalizedByConfig::String(task))
+                    }
+                }
+                FinalizedByConfig::Struct(fb) => {
+                    let task = tera.render_str(&fb.task, &context)?;
+                    if !task.ends_with("#") {
+                        let vars = render_value_map(&fb.vars, &mut tera, context).await?;
+                        rendered_finalized_by.push(FinalizedByConfig::Struct(FinalizedByConfigStruct { task, vars }));
+                    }
+                }
+            }
+        }
+        config.finalized_by = rendered_finalized_by;
 
         Ok(config)
     }
@@ -517,6 +538,89 @@ impl ConfigRenderer {
             depends_on.task = variant_task_name.clone();
 
             // Render dependency tasks recursively
+            Self::render_variant_tasks(
+                &variant_task_name,
+                root_config,
+                child_configs,
+                raw_root_config,
+                raw_child_configs,
+                num_variants,
+                contexts,
+            )
+            .await?;
+        }
+
+        // Render finalized_by task variants (same logic as depends_on)
+        for finalized_by in task_config.finalized_by.iter_mut() {
+            let FinalizedByConfig::Struct(finalized_by) = finalized_by else {
+                continue;
+            };
+            if finalized_by.vars.is_empty() {
+                continue;
+            };
+
+            let (fb_task, fb_project) = Self::get_task(&finalized_by.task, raw_root_config, raw_child_configs)
+                .context(format!(
+                    "unknown finalized_by task {:?} for {:?}",
+                    finalized_by.task, task_name
+                ))?;
+
+            let mut variant_task = fb_task.clone();
+
+            for (k, v) in finalized_by.vars.iter().filter(|(k, _)| fb_task.vars.contains_key(*k)) {
+                variant_task.vars.insert(k.clone(), v.clone());
+            }
+
+            let fb_context = contexts
+                .get(&fb_task.full_name())
+                .context(format!("unknown task {:?}", fb_task.full_name()))?;
+            let variant_context = variant_task.context(fb_project, fb_context).await?;
+
+            let mut rendered_variant_task = variant_task.render(&variant_context).await?;
+
+            debug!(
+                "Variant? (finalized_by): {:?}, finalizer of: {:?}\ncontext: {:#?}\nvars: {:#?}",
+                rendered_variant_task.full_name(),
+                task_name,
+                variant_context,
+                rendered_variant_task.vars,
+            );
+
+            if let Some(same_variant) =
+                Self::get_variant_tasks(&rendered_variant_task.full_name(), root_config, child_configs)
+                    .iter()
+                    .find(|t| {
+                        contexts
+                            .get(&t.full_name())
+                            .map(|c| *c == variant_context)
+                            .unwrap_or(false)
+                    })
+            {
+                finalized_by.task = same_variant.full_name();
+                continue;
+            }
+
+            let suffix = num_variants
+                .entry(fb_task.full_orig_name())
+                .and_modify(|v| *v += 1)
+                .or_insert(1);
+            let variant_task_name = format!("{}-{}", fb_task.full_name(), suffix);
+            rendered_variant_task.name = Task::split_name(&variant_task_name).1.to_string();
+
+            info!(
+                "Variant (finalized_by): {:?}, finalizer of: {:?}\ncontext: {:#?}\nvars: {:#?}",
+                rendered_variant_task.full_name(),
+                task_name,
+                variant_context,
+                rendered_variant_task.vars
+            );
+
+            contexts.insert(variant_task_name.clone(), variant_context);
+
+            Self::set_task(rendered_variant_task, root_config, child_configs);
+
+            finalized_by.task = variant_task_name.clone();
+
             Self::render_variant_tasks(
                 &variant_task_name,
                 root_config,

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,5 +1,5 @@
 use assertables::assert_starts_with;
-use firepit::config::{DependsOnConfig, ProjectConfig, ShellConfig};
+use firepit::config::{DependsOnConfig, FinalizedByConfig, ProjectConfig, ShellConfig};
 use indexmap::IndexMap;
 use std::path::Path;
 use std::sync::Once;
@@ -156,6 +156,33 @@ fn depends_on_names(task: &firepit::config::TaskConfig) -> Vec<String> {
             DependsOnConfig::Struct(s) => s.task.clone(),
         })
         .collect()
+}
+
+fn finalized_by_names(task: &firepit::config::TaskConfig) -> Vec<String> {
+    task.finalized_by
+        .iter()
+        .map(|f| match f {
+            FinalizedByConfig::String(s) => s.clone(),
+            FinalizedByConfig::Struct(s) => s.task.clone(),
+        })
+        .collect()
+}
+
+#[test]
+fn test_defaults_finalized_by() {
+    let path = Path::new("tests/fixtures/config/defaults_finalized_by");
+    let (root, _) = ProjectConfig::new_multi(path).unwrap();
+
+    // build and test should have finalized_by cleanup from defaults
+    let build = root.tasks.get("build").unwrap();
+    assert!(finalized_by_names(build).iter().any(|f| f.contains("cleanup")));
+
+    let test = root.tasks.get("test").unwrap();
+    assert!(finalized_by_names(test).iter().any(|f| f.contains("cleanup")));
+
+    // lint should NOT have finalized_by
+    let lint = root.tasks.get("lint").unwrap();
+    assert!(finalized_by_names(lint).is_empty());
 }
 
 #[test]

--- a/tests/fixtures/config/defaults_finalized_by/firepit.yml
+++ b/tests/fixtures/config/defaults_finalized_by/firepit.yml
@@ -1,0 +1,14 @@
+defaults:
+  - tasks: "^(build|test)"
+    finalized_by:
+      - cleanup
+
+tasks:
+  build:
+    command: echo "build"
+  test:
+    command: echo "test"
+  lint:
+    command: echo "lint"
+  cleanup:
+    command: echo "cleanup"

--- a/tests/fixtures/runner/finalized_by/firepit.yml
+++ b/tests/fixtures/runner/finalized_by/firepit.yml
@@ -1,0 +1,13 @@
+tasks:
+  foo:
+    command: echo "foo"
+    depends_on:
+      - bar
+    finalized_by:
+      - cleanup
+
+  bar:
+    command: echo "bar"
+
+  cleanup:
+    command: echo "cleanup"

--- a/tests/fixtures/runner/finalized_by_chain/firepit.yml
+++ b/tests/fixtures/runner/finalized_by_chain/firepit.yml
@@ -1,0 +1,13 @@
+tasks:
+  foo:
+    command: echo "foo"
+    finalized_by:
+      - bar
+
+  bar:
+    command: echo "bar"
+    finalized_by:
+      - baz
+
+  baz:
+    command: echo "baz"

--- a/tests/fixtures/runner/finalized_by_cyclic/firepit.yml
+++ b/tests/fixtures/runner/finalized_by_cyclic/firepit.yml
@@ -1,0 +1,10 @@
+tasks:
+  foo:
+    command: echo "foo"
+    finalized_by:
+      - bar
+
+  bar:
+    command: echo "bar"
+    finalized_by:
+      - foo

--- a/tests/fixtures/runner/finalized_by_failure/firepit.yml
+++ b/tests/fixtures/runner/finalized_by_failure/firepit.yml
@@ -1,0 +1,10 @@
+tasks:
+  foo:
+    command: |
+      echo "foo"
+      exit 1
+    finalized_by:
+      - cleanup
+
+  cleanup:
+    command: echo "cleanup"

--- a/tests/fixtures/runner/finalized_by_invalid/firepit.yml
+++ b/tests/fixtures/runner/finalized_by_invalid/firepit.yml
@@ -1,0 +1,5 @@
+tasks:
+  foo:
+    command: echo "foo"
+    finalized_by:
+      - nonexistent

--- a/tests/fixtures/runner/finalized_by_multi/firepit.yml
+++ b/tests/fixtures/runner/finalized_by_multi/firepit.yml
@@ -1,0 +1,3 @@
+projects:
+  p1: p1
+  p2: p2

--- a/tests/fixtures/runner/finalized_by_multi/p1/firepit.yml
+++ b/tests/fixtures/runner/finalized_by_multi/p1/firepit.yml
@@ -1,0 +1,5 @@
+tasks:
+  build:
+    command: echo "build"
+    finalized_by:
+      - p2#cleanup

--- a/tests/fixtures/runner/finalized_by_multi/p2/firepit.yml
+++ b/tests/fixtures/runner/finalized_by_multi/p2/firepit.yml
@@ -1,0 +1,3 @@
+tasks:
+  cleanup:
+    command: echo "cleanup"

--- a/tests/fixtures/runner/finalized_by_vars/firepit.yml
+++ b/tests/fixtures/runner/finalized_by_vars/firepit.yml
@@ -1,0 +1,19 @@
+tasks:
+  foo:
+    command: echo "foo"
+    finalized_by:
+      - task: cleanup
+        vars:
+          TARGET: foo
+
+  bar:
+    command: echo "bar"
+    finalized_by:
+      - task: cleanup
+        vars:
+          TARGET: bar
+
+  cleanup:
+    vars:
+      TARGET: default
+    command: echo "cleanup {{ TARGET }}"

--- a/tests/fixtures/runner/finalized_by_with_deps/firepit.yml
+++ b/tests/fixtures/runner/finalized_by_with_deps/firepit.yml
@@ -1,0 +1,15 @@
+tasks:
+  foo:
+    command: |
+      echo "foo"
+      exit 1
+    finalized_by:
+      - cleanup
+
+  cleanup:
+    command: echo "cleanup after setup"
+    depends_on:
+      - setup
+
+  setup:
+    command: echo "setup"

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -386,6 +386,39 @@ async fn test_finalized_by_failure() {
 }
 
 #[tokio::test]
+async fn test_finalized_by_vars() {
+    setup();
+    let path = BASE_PATH.join("finalized_by_vars");
+    let tasks = vec![String::from("foo"), String::from("bar")];
+
+    let mut statuses = HashMap::new();
+    statuses.insert(String::from("#foo"), String::from("Finished: Success"));
+    statuses.insert(String::from("#bar"), String::from("Finished: Success"));
+    statuses.insert(String::from("#cleanup-1"), String::from("Finished: Success"));
+    statuses.insert(String::from("#cleanup-2"), String::from("Finished: Success"));
+
+    let mut outputs = HashMap::new();
+    outputs.insert(String::from("#foo"), String::from("foo"));
+    outputs.insert(String::from("#bar"), String::from("bar"));
+    outputs.insert(String::from("#cleanup-1"), String::from("cleanup bar"));
+    outputs.insert(String::from("#cleanup-2"), String::from("cleanup foo"));
+
+    run_task(&path, tasks, statuses, Some(outputs), false).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_finalized_by_cyclic() {
+    setup();
+    let path = BASE_PATH.join("finalized_by_cyclic");
+    let tasks = vec![String::from("foo")];
+
+    let err = run_task(&path, tasks, HashMap::new(), None, false)
+        .await
+        .expect_err("should fail");
+    assert!(err.to_string().contains("cyclic dependency"));
+}
+
+#[tokio::test]
 async fn test_cyclic() {
     setup();
     let path = BASE_PATH.join("cyclic");

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -350,6 +350,42 @@ async fn test_vars_dynamic() {
 }
 
 #[tokio::test]
+async fn test_finalized_by() {
+    setup();
+    let path = BASE_PATH.join("finalized_by");
+    let tasks = vec![String::from("foo")];
+
+    let mut statuses = HashMap::new();
+    statuses.insert(String::from("#foo"), String::from("Finished: Success"));
+    statuses.insert(String::from("#bar"), String::from("Finished: Success"));
+    statuses.insert(String::from("#cleanup"), String::from("Finished: Success"));
+
+    let mut outputs = HashMap::new();
+    outputs.insert(String::from("#foo"), String::from("foo"));
+    outputs.insert(String::from("#bar"), String::from("bar"));
+    outputs.insert(String::from("#cleanup"), String::from("cleanup"));
+
+    run_task(&path, tasks, statuses, Some(outputs), false).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_finalized_by_failure() {
+    setup();
+    let path = BASE_PATH.join("finalized_by_failure");
+    let tasks = vec![String::from("foo")];
+
+    let mut statuses = HashMap::new();
+    statuses.insert(String::from("#foo"), String::from("Finished: Failure(1)"));
+    statuses.insert(String::from("#cleanup"), String::from("Finished: Success"));
+
+    let mut outputs = HashMap::new();
+    outputs.insert(String::from("#foo"), String::from("foo"));
+    outputs.insert(String::from("#cleanup"), String::from("cleanup"));
+
+    run_task(&path, tasks, statuses, Some(outputs), false).await.unwrap();
+}
+
+#[tokio::test]
 async fn test_cyclic() {
     setup();
     let path = BASE_PATH.join("cyclic");

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -419,6 +419,56 @@ async fn test_finalized_by_cyclic() {
 }
 
 #[tokio::test]
+async fn test_finalized_by_invalid() {
+    setup();
+    let path = BASE_PATH.join("finalized_by_invalid");
+    let tasks = vec![String::from("foo")];
+
+    let err = run_task(&path, tasks, HashMap::new(), None, false)
+        .await
+        .expect_err("should fail");
+    let msg = format!("{:?}", err);
+    assert!(msg.contains("finalized_by"));
+    assert!(msg.contains("nonexistent"));
+}
+
+#[tokio::test]
+async fn test_finalized_by_multi() {
+    setup();
+    let path = BASE_PATH.join("finalized_by_multi");
+    let tasks = vec![String::from("build")];
+
+    let mut statuses = HashMap::new();
+    statuses.insert(String::from("p1#build"), String::from("Finished: Success"));
+    statuses.insert(String::from("p2#cleanup"), String::from("Finished: Success"));
+
+    let mut outputs = HashMap::new();
+    outputs.insert(String::from("p1#build"), String::from("build"));
+    outputs.insert(String::from("p2#cleanup"), String::from("cleanup"));
+
+    run_task(&path, tasks, statuses, Some(outputs), false).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_finalized_by_with_deps() {
+    setup();
+    let path = BASE_PATH.join("finalized_by_with_deps");
+    let tasks = vec![String::from("foo")];
+
+    let mut statuses = HashMap::new();
+    statuses.insert(String::from("#foo"), String::from("Finished: Failure(1)"));
+    statuses.insert(String::from("#setup"), String::from("Finished: Success"));
+    statuses.insert(String::from("#cleanup"), String::from("Finished: Success"));
+
+    let mut outputs = HashMap::new();
+    outputs.insert(String::from("#foo"), String::from("foo"));
+    outputs.insert(String::from("#setup"), String::from("setup"));
+    outputs.insert(String::from("#cleanup"), String::from("cleanup after setup"));
+
+    run_task(&path, tasks, statuses, Some(outputs), false).await.unwrap();
+}
+
+#[tokio::test]
 async fn test_cyclic() {
     setup();
     let path = BASE_PATH.join("cyclic");

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -487,6 +487,51 @@ async fn test_finalized_by_chain() {
     run_task(&path, tasks, statuses, Some(outputs), false).await.unwrap();
 }
 
+/// Test that finalizer tasks are executed even with quit_on_done=true.
+/// Without the set_targets fix, quit_on_done would stop the runner before
+/// the finalizer has a chance to run.
+#[tokio::test]
+async fn test_finalized_by_quit_on_done() {
+    setup();
+    let path = BASE_PATH.join("finalized_by");
+    let tasks = vec![String::from("foo")];
+
+    let mut statuses = HashMap::new();
+    statuses.insert(String::from("#foo"), String::from("Finished: Success"));
+    statuses.insert(String::from("#bar"), String::from("Finished: Success"));
+    statuses.insert(String::from("#cleanup"), String::from("Finished: Success"));
+
+    let mut outputs = HashMap::new();
+    outputs.insert(String::from("#foo"), String::from("foo"));
+    outputs.insert(String::from("#bar"), String::from("bar"));
+    outputs.insert(String::from("#cleanup"), String::from("cleanup"));
+
+    // Use quit_on_done=true to verify finalizers are included in targets
+    let path = path::absolute(&path).unwrap();
+    let (root, children) = ProjectConfig::new_multi(&path).unwrap();
+    let ws = Workspace::new(&root, &children, &tasks, &path, &IndexMap::new(), false, false, Some(false), Some(false)).await.unwrap();
+    let mut runner = TaskRunner::new(&ws).unwrap();
+    let (app_tx, app_rx) = AppCommandChannel::new();
+    let runner_tx = runner.command_tx.clone();
+
+    let runner_fut = tokio::spawn(async move {
+        runner.run(&app_tx, true).await.ok();
+    });
+
+    let events_fut = handle_events(
+        app_rx,
+        runner_tx,
+        statuses,
+        Some(outputs),
+        None,
+        None,
+        None,
+    );
+
+    runner_fut.await.unwrap();
+    events_fut.await.unwrap();
+}
+
 #[tokio::test]
 async fn test_cyclic() {
     setup();

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -488,8 +488,8 @@ async fn test_finalized_by_chain() {
 }
 
 /// Test that finalizer tasks are executed even with quit_on_done=true.
-/// Without the set_targets fix, quit_on_done would stop the runner before
-/// the finalizer has a chance to run.
+/// Without the targets expansion fix, quit_on_done would stop the runner
+/// before the finalizer has a chance to run.
 #[tokio::test]
 async fn test_finalized_by_quit_on_done() {
     setup();
@@ -506,30 +506,25 @@ async fn test_finalized_by_quit_on_done() {
     outputs.insert(String::from("#bar"), String::from("bar"));
     outputs.insert(String::from("#cleanup"), String::from("cleanup"));
 
-    // Use quit_on_done=true to verify finalizers are included in targets
-    let path = path::absolute(&path).unwrap();
-    let (root, children) = ProjectConfig::new_multi(&path).unwrap();
-    let ws = Workspace::new(&root, &children, &tasks, &path, &IndexMap::new(), false, false, Some(false), Some(false)).await.unwrap();
-    let mut runner = TaskRunner::new(&ws).unwrap();
-    let (app_tx, app_rx) = AppCommandChannel::new();
-    let runner_tx = runner.command_tx.clone();
+    run_task_inner_with_opts(&path, tasks, statuses, Some(outputs), None, None, None, IndexMap::new(), false, true).await.unwrap();
+}
 
-    let runner_fut = tokio::spawn(async move {
-        runner.run(&app_tx, true).await.ok();
-    });
+/// Test that a finalizer is NOT scheduled when its finalized task is not in the execution graph.
+/// Running only "bar" should not trigger "cleanup" (which is foo's finalizer).
+#[tokio::test]
+async fn test_finalized_by_not_in_graph() {
+    setup();
+    let path = BASE_PATH.join("finalized_by");
+    let tasks = vec![String::from("bar")];
 
-    let events_fut = handle_events(
-        app_rx,
-        runner_tx,
-        statuses,
-        Some(outputs),
-        None,
-        None,
-        None,
-    );
+    let mut statuses = HashMap::new();
+    statuses.insert(String::from("#bar"), String::from("Finished: Success"));
 
-    runner_fut.await.unwrap();
-    events_fut.await.unwrap();
+    let mut outputs = HashMap::new();
+    outputs.insert(String::from("#bar"), String::from("bar"));
+
+    // Only bar runs; foo and cleanup should NOT be in the graph
+    run_task(&path, tasks, statuses, Some(outputs), false).await.unwrap();
 }
 
 #[tokio::test]
@@ -774,6 +769,21 @@ async fn run_task_inner(
     vars: IndexMap<String, VarsConfig>,
     force: bool,
 ) -> anyhow::Result<()> {
+    run_task_inner_with_opts(path, tasks, status_expected, outputs_expected, restarts_expected, runs_expected, timeout_seconds, vars, force, false).await
+}
+
+async fn run_task_inner_with_opts(
+    path: &Path,
+    tasks: Vec<String>,
+    status_expected: HashMap<String, String>,
+    outputs_expected: Option<HashMap<String, String>>,
+    restarts_expected: Option<HashMap<String, u64>>,
+    runs_expected: Option<HashMap<String, u64>>,
+    timeout_seconds: Option<u64>,
+    vars: IndexMap<String, VarsConfig>,
+    force: bool,
+    quit_on_done: bool,
+) -> anyhow::Result<()> {
     let path = path::absolute(path)?;
     let (root, children) = ProjectConfig::new_multi(&path)?;
     let ws = Workspace::new(&root, &children, &tasks, &path, &vars, force, false, Some(false), Some(false)).await?;
@@ -785,7 +795,7 @@ async fn run_task_inner(
 
     // Start runner
     let runner_fut = tokio::spawn(async move {
-        runner.run(&app_tx, false).await.ok();
+        runner.run(&app_tx, quit_on_done).await.ok();
     });
 
     // Handle events and assert task statuses

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -487,26 +487,23 @@ async fn test_finalized_by_chain() {
     run_task(&path, tasks, statuses, Some(outputs), false).await.unwrap();
 }
 
-/// Test that finalizer tasks are executed even with quit_on_done=true.
-/// Without the targets expansion fix, quit_on_done would stop the runner
-/// before the finalizer has a chance to run.
+/// Test that TaskGraph.targets() includes finalizer tasks.
+/// This ensures quit_on_done waits for finalizers before stopping.
 #[tokio::test]
-async fn test_finalized_by_quit_on_done() {
+async fn test_finalized_by_targets_include_finalizers() {
     setup();
     let path = BASE_PATH.join("finalized_by");
     let tasks = vec![String::from("foo")];
 
-    let mut statuses = HashMap::new();
-    statuses.insert(String::from("#foo"), String::from("Finished: Success"));
-    statuses.insert(String::from("#bar"), String::from("Finished: Success"));
-    statuses.insert(String::from("#cleanup"), String::from("Finished: Success"));
+    let path = path::absolute(&path).unwrap();
+    let (root, children) = ProjectConfig::new_multi(&path).unwrap();
+    let ws = Workspace::new(&root, &children, &tasks, &path, &IndexMap::new(), false, false, Some(false), Some(false)).await.unwrap();
+    let runner = TaskRunner::new(&ws).unwrap();
+    let targets = runner.task_graph.targets();
 
-    let mut outputs = HashMap::new();
-    outputs.insert(String::from("#foo"), String::from("foo"));
-    outputs.insert(String::from("#bar"), String::from("bar"));
-    outputs.insert(String::from("#cleanup"), String::from("cleanup"));
-
-    run_task_inner_with_opts(&path, tasks, statuses, Some(outputs), None, None, None, IndexMap::new(), false, true).await.unwrap();
+    // "#foo" is the explicit target, "#cleanup" should be auto-added as foo's finalizer
+    assert!(targets.contains("#foo"), "targets should contain the explicit target");
+    assert!(targets.contains("#cleanup"), "targets should contain the finalizer task");
 }
 
 /// Test that a finalizer is NOT scheduled when its finalized task is not in the execution graph.
@@ -769,21 +766,6 @@ async fn run_task_inner(
     vars: IndexMap<String, VarsConfig>,
     force: bool,
 ) -> anyhow::Result<()> {
-    run_task_inner_with_opts(path, tasks, status_expected, outputs_expected, restarts_expected, runs_expected, timeout_seconds, vars, force, false).await
-}
-
-async fn run_task_inner_with_opts(
-    path: &Path,
-    tasks: Vec<String>,
-    status_expected: HashMap<String, String>,
-    outputs_expected: Option<HashMap<String, String>>,
-    restarts_expected: Option<HashMap<String, u64>>,
-    runs_expected: Option<HashMap<String, u64>>,
-    timeout_seconds: Option<u64>,
-    vars: IndexMap<String, VarsConfig>,
-    force: bool,
-    quit_on_done: bool,
-) -> anyhow::Result<()> {
     let path = path::absolute(path)?;
     let (root, children) = ProjectConfig::new_multi(&path)?;
     let ws = Workspace::new(&root, &children, &tasks, &path, &vars, force, false, Some(false), Some(false)).await?;
@@ -795,7 +777,7 @@ async fn run_task_inner_with_opts(
 
     // Start runner
     let runner_fut = tokio::spawn(async move {
-        runner.run(&app_tx, quit_on_done).await.ok();
+        runner.run(&app_tx, false).await.ok();
     });
 
     // Handle events and assert task statuses

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -469,6 +469,25 @@ async fn test_finalized_by_with_deps() {
 }
 
 #[tokio::test]
+async fn test_finalized_by_chain() {
+    setup();
+    let path = BASE_PATH.join("finalized_by_chain");
+    let tasks = vec![String::from("foo")];
+
+    let mut statuses = HashMap::new();
+    statuses.insert(String::from("#foo"), String::from("Finished: Success"));
+    statuses.insert(String::from("#bar"), String::from("Finished: Success"));
+    statuses.insert(String::from("#baz"), String::from("Finished: Success"));
+
+    let mut outputs = HashMap::new();
+    outputs.insert(String::from("#foo"), String::from("foo"));
+    outputs.insert(String::from("#bar"), String::from("bar"));
+    outputs.insert(String::from("#baz"), String::from("baz"));
+
+    run_task(&path, tasks, statuses, Some(outputs), false).await.unwrap();
+}
+
+#[tokio::test]
 async fn test_cyclic() {
     setup();
     let path = BASE_PATH.join("cyclic");


### PR DESCRIPTION
## Summary

- Add `finalized_by` configuration option for tasks, similar to Gradle's `finalizedBy`
- Finalizer tasks run after the specified task completes, regardless of success or failure
- Support `vars` for finalizer tasks (same as `depends_on`), enabling variant task generation
- Cyclic dependencies involving `finalized_by` are properly detected
- Finalizer tasks are included in `target_tasks` so `quit_on_done` waits for them
- Finalizer task failures result in non-zero exit code

### Configuration example

```yaml
tasks:
  build:
    command: cargo build
    finalized_by:
      - cleanup
      - task: report
        vars:
          output_dir: dist

  cleanup:
    command: rm -rf tmp

  report:
    vars:
      output_dir: build
    command: echo "Report for {{ output_dir }}"
```

## Test plan

- [x] Basic finalized_by execution (`test_finalized_by`)
- [x] Finalizer runs on task failure (`test_finalized_by_failure`)
- [x] Same finalizer with different vars generates variant tasks (`test_finalized_by_vars`)
- [x] Cyclic finalized_by references detected (`test_finalized_by_cyclic`)
- [x] All 71 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)