### PR TITLE
feat(runner): execute finalized_by tasks on graceful quit

### DIFF
--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -173,14 +173,6 @@ impl ProcessManager {
         }
     }
 
-    /// Re-open the process manager after a close, allowing new processes to be spawned.
-    /// Used during the finalization phase of shutdown, where finalizer tasks
-    /// need to spawn new processes after the main tasks have been stopped.
-    pub async fn reopen(&self) {
-        let mut lock = self.state.lock().await;
-        lock.is_closing = false;
-    }
-
     pub async fn is_closed(&self) -> bool {
         self.state.lock().await.is_closing
     }

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -173,6 +173,14 @@ impl ProcessManager {
         }
     }
 
+    /// Re-open the process manager after a close, allowing new processes to be spawned.
+    /// Used during the finalization phase of shutdown, where finalizer tasks
+    /// need to spawn new processes after the main tasks have been stopped.
+    pub async fn reopen(&self) {
+        let mut lock = self.state.lock().await;
+        lock.is_closing = false;
+    }
+
     pub async fn is_closed(&self) -> bool {
         self.state.lock().await.is_closing
     }

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -12,6 +12,7 @@
 mod child;
 mod command;
 
+use std::collections::HashSet;
 use std::{io, sync::Arc, time::Duration};
 
 pub use self::child::{Child, ChildExit};
@@ -109,7 +110,11 @@ impl ProcessManager {
     }
 
     pub async fn stop(&self) -> Vec<ChildExit> {
-        self.stop_inner(|c| true).await
+        self.stop_inner(|_c| true).await
+    }
+
+    pub async fn stop_except_labels(&self, labels: &HashSet<String>) -> Vec<ChildExit> {
+        self.stop_inner(|c| !labels.contains(c.label())).await
     }
 
     async fn stop_inner<F>(&self, filter: F) -> Vec<ChildExit>

--- a/src/runner/graph.rs
+++ b/src/runner/graph.rs
@@ -230,21 +230,40 @@ impl TaskGraph {
             let targets_remaining_cloned = targets_remaining.clone();
             let visitor_tx_cloned = visitor_tx.clone();
             nodes_fut.push(tokio_spawn!("node", { name = task_name }, async move {
-                // Handle Finalize command: finalizer visitors continue, non-finalizer visitors stop.
-                macro_rules! handle_finalize {
-                    ($msg:expr) => {
-                        if is_finalizer {
-                            debug!($msg);
-                            continue
-                        }
-                        debug!("Non-finalizer visitor stopped by Finalize");
-                        return Ok(());
-                    };
-                }
                 let mut ignore_deps = false;
                 let mut num_runs = 0;
                 let mut num_restart = 0;
                 'start: loop {
+                    // Handle visitor commands consistently across all 3 wait points
+                    // (dep-wait, callback-wait, post-completion).
+                    macro_rules! handle_visitor_command {
+                        ($command:expr, $finalize_msg:expr) => {
+                            match $command {
+                                VisitorCommand::Stop => {
+                                    debug!("Visitor stopped");
+                                    return Ok(());
+                                }
+                                VisitorCommand::Finalize => {
+                                    if is_finalizer {
+                                        debug!($finalize_msg);
+                                        continue
+                                    }
+                                    debug!("Non-finalizer visitor stopped by Finalize");
+                                    return Ok(());
+                                }
+                                VisitorCommand::Restart { task: task_name, force } => {
+                                    if task.name == task_name {
+                                        debug!("Visitor restarted");
+                                        ignore_deps = force;
+                                        num_runs += 1;
+                                        tx.send(NodeResult::None).ok();
+                                        continue 'start;
+                                    }
+                                    continue
+                                }
+                            }
+                        };
+                    }
                     if dep_tasks.is_empty() {
                         info!("No dependency")
                     } else {
@@ -262,25 +281,7 @@ impl TaskGraph {
                             tokio::select! {
                                 // Visitor command branch
                                 Ok(command) = visitor_rx.recv() => {
-                                    match command {
-                                        VisitorCommand::Stop => {
-                                            debug!("Visitor stopped");
-                                            return Ok(())
-                                        }
-                                        VisitorCommand::Finalize => {
-                                            handle_finalize!("Finalizer visitor continuing to wait for deps");
-                                        }
-                                        VisitorCommand::Restart { task: task_name, force } => {
-                                            debug!("Visitor restarted");
-                                            if task.name == task_name {
-                                                ignore_deps = force;
-                                                num_runs += 1;
-                                                tx.send(NodeResult::None).ok();
-                                                continue 'start;
-                                            }
-                                            continue
-                                        }
-                                    };
+                                    handle_visitor_command!(command, "Finalizer visitor continuing to wait for deps");
                                 }
                                 // Normal branch, waiting for all dependency tasks
                                 Ok(deps_ok) = Self::wait_all_watches(dep_rxs.clone()) => {
@@ -309,25 +310,7 @@ impl TaskGraph {
                                     tokio::select! {
                                         // Visitor command branch
                                         Ok(command) = visitor_rx.recv() => {
-                                            match command {
-                                                VisitorCommand::Stop => {
-                                                    debug!("Visitor stopped");
-                                                    return Ok(())
-                                                }
-                                                VisitorCommand::Finalize => {
-                                                    handle_finalize!("Finalizer visitor continuing to wait for callback");
-                                                }
-                                                VisitorCommand::Restart { task: task_name, force } => {
-                                                    debug!("Visitor restarted");
-                                                    if task.name == task_name {
-                                                        ignore_deps = force;
-                                                        num_runs += 1;
-                                                        tx.send(NodeResult::None).ok();
-                                                        continue 'start;
-                                                    }
-                                                    continue 'recv
-                                                }
-                                            };
+                                            handle_visitor_command!(command, "Finalizer visitor continuing to wait for callback");
                                         }
                                         // Normal branch, waiting for the node result
                                         result = callback_rx.recv() => {
@@ -392,24 +375,9 @@ impl TaskGraph {
 
                     loop {
                         match visitor_rx.recv().await {
-                            Ok(command) => match command {
-                                VisitorCommand::Stop => {
-                                    debug!("Visitor stopped");
-                                    return Ok(());
-                                }
-                                VisitorCommand::Finalize => {
-                                    handle_finalize!("Finalizer visitor already completed, ignoring Finalize");
-                                }
-                                VisitorCommand::Restart { task: task_name, force } => {
-                                    if task.name == task_name {
-                                        debug!("Visitor restarted");
-                                        num_runs += 1;
-                                        ignore_deps = force;
-                                        tx.send(NodeResult::None).ok();
-                                        continue 'start;
-                                    }
-                                }
-                            },
+                            Ok(command) => {
+                                handle_visitor_command!(command, "Finalizer visitor already completed, ignoring Finalize");
+                            }
                             Err(broadcast::error::RecvError::Closed) => {
                                 debug!("Visitor command channel closed");
                                 return Ok(());

--- a/src/runner/graph.rs
+++ b/src/runner/graph.rs
@@ -39,6 +39,8 @@ pub struct VisitorMessage {
 pub enum VisitorCommand {
     Stop,
     Restart { task: String, force: bool },
+    /// Graceful shutdown: stop non-finalizer visitors, let finalizer visitors continue
+    Finalize,
 }
 
 pub struct VisitorHandle {
@@ -192,6 +194,9 @@ impl TaskGraph {
         let targets_remaining: HashSet<String> = self.targets.clone();
         let targets_remaining = Arc::new(Mutex::new(targets_remaining));
 
+        // Compute finalizer task names
+        let finalizer_set = self.finalizer_names();
+
         // Run visitor thread for all nodes
         let nodes_fut = FuturesUnordered::new();
         for node_id in self.graph.node_identifiers() {
@@ -221,6 +226,7 @@ impl TaskGraph {
                 .collect::<anyhow::Result<Vec<_>>>()?;
 
             let task_name = task.name.clone();
+            let is_finalizer = finalizer_set.contains(&task.name);
             let targets_remaining_cloned = targets_remaining.clone();
             let visitor_tx_cloned = visitor_tx.clone();
             nodes_fut.push(tokio_spawn!("node", { name = task_name }, async move {
@@ -249,6 +255,14 @@ impl TaskGraph {
                                         VisitorCommand::Stop => {
                                             debug!("Visitor stopped");
                                             return Ok(())
+                                        }
+                                        VisitorCommand::Finalize => {
+                                            if is_finalizer {
+                                                debug!("Finalizer visitor continuing to wait for deps");
+                                                continue
+                                            }
+                                            debug!("Non-finalizer visitor stopped by Finalize");
+                                            return Ok(());
                                         }
                                         VisitorCommand::Restart { task: task_name, force } => {
                                             debug!("Visitor restarted");
@@ -293,6 +307,14 @@ impl TaskGraph {
                                                 VisitorCommand::Stop => {
                                                     debug!("Visitor stopped");
                                                     return Ok(())
+                                                }
+                                                VisitorCommand::Finalize => {
+                                                    if is_finalizer {
+                                                        debug!("Finalizer visitor continuing to wait for callback");
+                                                        continue 'recv
+                                                    }
+                                                    debug!("Non-finalizer visitor stopped by Finalize");
+                                                    return Ok(());
                                                 }
                                                 VisitorCommand::Restart { task: task_name, force } => {
                                                     debug!("Visitor restarted");
@@ -374,6 +396,15 @@ impl TaskGraph {
                                     debug!("Visitor stopped");
                                     return Ok(());
                                 }
+                                VisitorCommand::Finalize => {
+                                    // Finalizer already completed, nothing to do
+                                    if is_finalizer {
+                                        debug!("Finalizer visitor already completed, ignoring Finalize");
+                                        continue;
+                                    }
+                                    debug!("Non-finalizer visitor stopped by Finalize");
+                                    return Ok(());
+                                }
                                 VisitorCommand::Restart { task: task_name, force } => {
                                     if task.name == task_name {
                                         debug!("Visitor restarted");
@@ -406,6 +437,18 @@ impl TaskGraph {
 
     pub fn targets(&self) -> &HashSet<String> {
         &self.targets
+    }
+
+    /// Returns the set of task names that are finalizer tasks
+    /// (appear in some task's `finalized_by` list).
+    pub fn finalizer_names(&self) -> HashSet<String> {
+        let mut finalizers = HashSet::new();
+        for task in self.graph.node_weights() {
+            for f in &task.finalized_by {
+                finalizers.insert(f.clone());
+            }
+        }
+        finalizers
     }
 
     pub fn transitive_closure(&self, names: &Vec<String>, direction: Direction) -> anyhow::Result<TaskGraph> {

--- a/src/runner/graph.rs
+++ b/src/runner/graph.rs
@@ -230,6 +230,17 @@ impl TaskGraph {
             let targets_remaining_cloned = targets_remaining.clone();
             let visitor_tx_cloned = visitor_tx.clone();
             nodes_fut.push(tokio_spawn!("node", { name = task_name }, async move {
+                // Handle Finalize command: finalizer visitors continue, non-finalizer visitors stop.
+                macro_rules! handle_finalize {
+                    ($msg:expr) => {
+                        if is_finalizer {
+                            debug!($msg);
+                            continue
+                        }
+                        debug!("Non-finalizer visitor stopped by Finalize");
+                        return Ok(());
+                    };
+                }
                 let mut ignore_deps = false;
                 let mut num_runs = 0;
                 let mut num_restart = 0;
@@ -257,12 +268,7 @@ impl TaskGraph {
                                             return Ok(())
                                         }
                                         VisitorCommand::Finalize => {
-                                            if is_finalizer {
-                                                debug!("Finalizer visitor continuing to wait for deps");
-                                                continue
-                                            }
-                                            debug!("Non-finalizer visitor stopped by Finalize");
-                                            return Ok(());
+                                            handle_finalize!("Finalizer visitor continuing to wait for deps");
                                         }
                                         VisitorCommand::Restart { task: task_name, force } => {
                                             debug!("Visitor restarted");
@@ -309,12 +315,7 @@ impl TaskGraph {
                                                     return Ok(())
                                                 }
                                                 VisitorCommand::Finalize => {
-                                                    if is_finalizer {
-                                                        debug!("Finalizer visitor continuing to wait for callback");
-                                                        continue 'recv
-                                                    }
-                                                    debug!("Non-finalizer visitor stopped by Finalize");
-                                                    return Ok(());
+                                                    handle_finalize!("Finalizer visitor continuing to wait for callback");
                                                 }
                                                 VisitorCommand::Restart { task: task_name, force } => {
                                                     debug!("Visitor restarted");
@@ -397,13 +398,7 @@ impl TaskGraph {
                                     return Ok(());
                                 }
                                 VisitorCommand::Finalize => {
-                                    // Finalizer already completed, nothing to do
-                                    if is_finalizer {
-                                        debug!("Finalizer visitor already completed, ignoring Finalize");
-                                        continue;
-                                    }
-                                    debug!("Non-finalizer visitor stopped by Finalize");
-                                    return Ok(());
+                                    handle_finalize!("Finalizer visitor already completed, ignoring Finalize");
                                 }
                                 VisitorCommand::Restart { task: task_name, force } => {
                                     if task.name == task_name {

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -13,8 +13,7 @@ use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use indexmap::IndexMap;
 use petgraph::Direction;
-use std::collections::{HashMap, HashSet};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::sync::mpsc::UnboundedReceiver;
@@ -128,7 +127,7 @@ impl TaskRunner {
         let mut task_fut = FuturesUnordered::new();
         let targets_remaining = self.task_graph.targets().clone();
         let targets_remaining = Arc::new(Mutex::new(targets_remaining));
-        let is_finalizing = Arc::new(AtomicBool::new(false));
+        let is_finalizing = Arc::new(Mutex::new(false));
 
         while !node_rx.is_closed() {
             tokio::select! {
@@ -171,7 +170,7 @@ impl TaskRunner {
                         }
                         RunnerCommand::Quit => {
                             // If already finalizing, force quit
-                            if is_finalizing.load(Ordering::SeqCst) {
+                            if *is_finalizing.lock().expect("not poisoned") {
                                 info!("Force killing remaining finalizer tasks");
                                 self.manager.close_by_kill().await;
                                 if let Err(err) = visitor_tx.send(VisitorCommand::Stop) {
@@ -211,7 +210,7 @@ impl TaskRunner {
                             }
 
                             // Set flag so task futures know to stop visitors when all targets are done
-                            is_finalizing.store(true, Ordering::SeqCst);
+                            *is_finalizing.lock().expect("not poisoned") = true;
                         }
                     }
                 }
@@ -420,7 +419,7 @@ impl TaskRunner {
                             t.remove(&task.name);
                             t.is_empty()
                         };
-                        if (quit_on_done || is_finalizing_cloned.load(Ordering::SeqCst)) && targets_done {
+                        if (quit_on_done || *is_finalizing_cloned.lock().expect("not poisoned")) && targets_done {
                             info!("All target tasks done, stopping visitors");
                             visitor_tx_cloned.send(VisitorCommand::Stop).ok();
                         }

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -127,6 +127,7 @@ impl TaskRunner {
         let mut task_fut = FuturesUnordered::new();
         let targets_remaining = self.task_graph.targets().clone();
         let targets_remaining = Arc::new(Mutex::new(targets_remaining));
+        let finalizer_names = self.task_graph.finalizer_names();
         let is_finalizing = Arc::new(Mutex::new(false));
 
         while !node_rx.is_closed() {
@@ -183,7 +184,6 @@ impl TaskRunner {
                             info!("Stopping runner");
 
                             // Check for pending finalizer tasks before stopping
-                            let finalizer_names = self.task_graph.finalizer_names();
                             let has_pending_finalizers = {
                                 let remaining = targets_remaining.lock().expect("not poisoned");
                                 finalizer_names.iter().any(|f| remaining.contains(f))

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -182,35 +182,19 @@ impl TaskRunner {
                             }
 
                             info!("Stopping runner");
-                            info!("Stopping tasks");
-                            let force_quit = tokio::select! {
-                                Ok(RunnerCommand::Quit) = self.command_rx.recv() => {
-                                    info!("Killing tasks");
-                                    self.manager.close_by_kill().await;
-                                    info!("Killed tasks");
-                                    true
-                                }
-                                _ = self.manager.close() => {
-                                    info!("Stopped tasks");
-                                    false
-                                }
-                            };
 
-                            if force_quit {
-                                info!("Stopping all visitors (force quit)");
-                                if let Err(err) = visitor_tx.send(VisitorCommand::Stop) {
-                                    warn!("Failed to stop visitors: {:?}", err);
-                                }
-                                node_rx.close();
-                                continue;
-                            }
-
-                            // Check for finalizer tasks that still need to run
+                            // Check for pending finalizer tasks before stopping
                             let finalizer_names = self.task_graph.finalizer_names();
                             let has_pending_finalizers = {
                                 let remaining = targets_remaining.lock().expect("not poisoned");
                                 finalizer_names.iter().any(|f| remaining.contains(f))
                             };
+
+                            // Stop non-finalizer tasks
+                            info!("Stopping tasks");
+                            self.manager.stop().await;
+                            info!("Stopped tasks");
+
                             if !has_pending_finalizers {
                                 info!("No pending finalizer tasks, stopping visitors");
                                 if let Err(err) = visitor_tx.send(VisitorCommand::Stop) {
@@ -219,10 +203,6 @@ impl TaskRunner {
                                 node_rx.close();
                                 continue;
                             }
-
-                            // Reopen process manager so finalizer processes can spawn
-                            info!("Reopening process manager for finalizer tasks");
-                            self.manager.reopen().await;
 
                             // Send Finalize: stops non-finalizer visitors, lets finalizer visitors continue
                             info!("Sending Finalize to visitors, {} finalizers pending", finalizer_names.len());

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -190,9 +190,9 @@ impl TaskRunner {
                                 finalizer_names.iter().any(|f| remaining.contains(f))
                             };
 
-                            // Stop non-finalizer tasks
+                            // Stop non-finalizer tasks (preserve running finalizers)
                             info!("Stopping tasks");
-                            self.manager.stop().await;
+                            self.manager.stop_except_labels(&finalizer_names).await;
                             info!("Stopped tasks");
 
                             if !has_pending_finalizers {

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -14,6 +14,7 @@ use futures::StreamExt;
 use indexmap::IndexMap;
 use petgraph::Direction;
 use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::sync::mpsc::UnboundedReceiver;
@@ -127,6 +128,7 @@ impl TaskRunner {
         let mut task_fut = FuturesUnordered::new();
         let targets_remaining = self.task_graph.targets().clone();
         let targets_remaining = Arc::new(Mutex::new(targets_remaining));
+        let is_finalizing = Arc::new(AtomicBool::new(false));
 
         while !node_rx.is_closed() {
             tokio::select! {
@@ -168,36 +170,85 @@ impl TaskRunner {
                             }
                         }
                         RunnerCommand::Quit => {
+                            // If already finalizing, force quit
+                            if is_finalizing.load(Ordering::SeqCst) {
+                                info!("Force killing remaining finalizer tasks");
+                                self.manager.close_by_kill().await;
+                                if let Err(err) = visitor_tx.send(VisitorCommand::Stop) {
+                                    warn!("Failed to stop visitors: {:?}", err);
+                                }
+                                node_rx.close();
+                                continue;
+                            }
+
                             info!("Stopping runner");
                             info!("Stopping tasks");
-                            tokio::select! {
+                            let force_quit = tokio::select! {
                                 Ok(RunnerCommand::Quit) = self.command_rx.recv() => {
                                     info!("Killing tasks");
                                     self.manager.close_by_kill().await;
                                     info!("Killed tasks");
+                                    true
                                 }
-                                _ =  self.manager.close() => {
+                                _ = self.manager.close() => {
                                     info!("Stopped tasks");
+                                    false
                                 }
+                            };
+
+                            if force_quit {
+                                info!("Stopping all visitors (force quit)");
+                                if let Err(err) = visitor_tx.send(VisitorCommand::Stop) {
+                                    warn!("Failed to stop visitors: {:?}", err);
+                                }
+                                node_rx.close();
+                                continue;
                             }
-                            info!("Stopping visitors");
-                            if let Err(err) = visitor_tx.send(VisitorCommand::Stop) {
-                                warn!("Failed to stop visitors: {:?}", err);
+
+                            // Check for finalizer tasks that still need to run
+                            let finalizer_names = self.task_graph.finalizer_names();
+                            let has_pending_finalizers = {
+                                let remaining = targets_remaining.lock().expect("not poisoned");
+                                finalizer_names.iter().any(|f| remaining.contains(f))
+                            };
+                            if !has_pending_finalizers {
+                                info!("No pending finalizer tasks, stopping visitors");
+                                if let Err(err) = visitor_tx.send(VisitorCommand::Stop) {
+                                    warn!("Failed to stop visitors: {:?}", err);
+                                }
+                                node_rx.close();
+                                continue;
                             }
-                            node_rx.close();
+
+                            // Reopen process manager so finalizer processes can spawn
+                            info!("Reopening process manager for finalizer tasks");
+                            self.manager.reopen().await;
+
+                            // Send Finalize: stops non-finalizer visitors, lets finalizer visitors continue
+                            info!("Sending Finalize to visitors, {} finalizers pending", finalizer_names.len());
+                            if let Err(err) = visitor_tx.send(VisitorCommand::Finalize) {
+                                warn!("Failed to send Finalize: {:?}", err);
+                            }
+
+                            // Set flag so task futures know to stop visitors when all targets are done
+                            is_finalizing.store(true, Ordering::SeqCst);
                         }
                     }
                 }
 
                 // Visitor message branch
-                Some(message) = node_rx.recv() => {
-                    let VisitorMessage {
+                message = node_rx.recv() => {
+                    let Some(VisitorMessage {
                         node: task,
                         deps_ok,
                         num_runs,
                         num_restart,
                         callback,
-                    } = message;
+                    }) = message else {
+                        // All visitor senders dropped, no more tasks to run
+                        info!("All visitors finished, exiting main loop");
+                        break;
+                    };
 
                     let mut app_tx = app_tx.clone().with_name(&task.name);
                     let fail_fast = self.fail_fast;
@@ -206,6 +257,7 @@ impl TaskRunner {
                     let task_name = task.name.clone();
                     let visitor_tx_cloned = visitor_tx.clone();
                     let targets_remaining_cloned = targets_remaining.clone();
+                    let is_finalizing_cloned = is_finalizing.clone();
                     let start_times_cloned = self.start_times.clone();
                     let end_times_cloned = self.end_times.clone();
                     task_fut.push(tokio_spawn!("task", { name = task_name }, async move {
@@ -388,7 +440,7 @@ impl TaskRunner {
                             t.remove(&task.name);
                             t.is_empty()
                         };
-                        if quit_on_done && targets_done {
+                        if (quit_on_done || is_finalizing_cloned.load(Ordering::SeqCst)) && targets_done {
                             info!("All target tasks done, stopping visitors");
                             visitor_tx_cloned.send(VisitorCommand::Stop).ok();
                         }

--- a/tests/fixtures/runner/finalized_by_service/firepit.yml
+++ b/tests/fixtures/runner/finalized_by_service/firepit.yml
@@ -1,0 +1,8 @@
+tasks:
+  server:
+    command: sleep 3600
+    service: true
+    finalized_by:
+      - cleanup
+  cleanup:
+    command: echo "cleanup done"

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -953,3 +953,90 @@ fn handle_events(
         }
     })
 }
+
+/// Test that finalized_by tasks run when a service is stopped via Quit.
+/// The cleanup task should execute after the service is gracefully stopped.
+#[tokio::test]
+async fn test_finalized_by_service_quit() {
+    setup();
+    let path = BASE_PATH.join("finalized_by_service");
+    let tasks = vec![String::from("server")];
+
+    let path = path::absolute(&path).unwrap();
+    let (root, children) = ProjectConfig::new_multi(&path).unwrap();
+    let ws = Workspace::new(
+        &root,
+        &children,
+        &tasks,
+        &path,
+        &IndexMap::new(),
+        false,
+        false,
+        Some(false),
+        Some(false),
+    )
+    .await
+    .unwrap();
+
+    let mut runner = TaskRunner::new(&ws).unwrap();
+    let (app_tx, mut app_rx) = AppCommandChannel::new();
+    let runner_tx = runner.command_tx();
+
+    let runner_fut = tokio::spawn(async move {
+        runner.run(&app_tx, false).await.ok();
+    });
+
+    let events_fut = tokio::spawn(async move {
+        let mut statuses = HashMap::new();
+        let mut quit_sent = false;
+
+        let timeout = tokio::time::sleep(Duration::from_secs(DEFAULT_TEST_TIMEOUT_SECONDS));
+        tokio::pin!(timeout);
+
+        loop {
+            tokio::select! {
+                _ = &mut timeout => {
+                    panic!(
+                        "Test timed out. Statuses so far: {:?}",
+                        statuses
+                    );
+                }
+                Some(event) = app_rx.recv() => {
+                    match event {
+                        AppCommand::ReadyTask { task } => {
+                            statuses.insert(task.clone(), String::from("Ready"));
+                            // Service is ready, send Quit to trigger finalization
+                            if !quit_sent && task == "#server" {
+                                runner_tx.quit();
+                                quit_sent = true;
+                            }
+                        }
+                        AppCommand::FinishTask { task, result, .. } => {
+                            statuses.insert(task.clone(), format!("Finished: {:?}", result));
+                        }
+                        AppCommand::Quit => {
+                            break;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+
+            // Check if cleanup finished after quit was sent
+            if quit_sent && statuses.get("#cleanup").is_some() {
+                break;
+            }
+        }
+
+        // Assert that the cleanup task ran successfully
+        assert_eq!(
+            statuses.get("#cleanup"),
+            Some(&String::from("Finished: Success")),
+            "Cleanup finalizer should have run after quit. Statuses: {:?}",
+            statuses
+        );
+    });
+
+    runner_fut.await.unwrap();
+    events_fut.await.unwrap();
+}


### PR DESCRIPTION
## Summary
- `q` キーによるグレースフルシャットダウン時に `finalized_by` タスクを実行するように変更
- 1回目の `q` で非finalizer タスクを停止し、pending finalizer を実行して完了を待機
- 2回目の `q` で残りの全タスクを SIGKILL で強制終了
- 実行中の finalizer プロセスは1回目の `q` では停止されない（`stop_except_labels()`）

## Changes
- `VisitorCommand::Finalize` を追加し、非finalizer visitor のみ停止
- `ProcessManager::stop_except_labels()` で finalizer プロセスを保護
- `handle_visitor_command!` マクロで visitor コマンドハンドリングの重複を解消
- 統合テスト `test_finalized_by_service_quit` を追加

## Test plan
- [x] `cargo test` 全テスト通過（32 + 12 + 3 + 32）
- [x] `test_finalized_by_service_quit`: サービス起動 → Quit → cleanup finalizer 実行を検証
- [ ] 手動テスト: TUI で `q` 押下時に finalizer が実行されることを確認
- [ ] 手動テスト: 2回目の `q` で強制終了されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)