### PR TITLE
chore: add lefthook hooks and CI guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,59 @@ on:
     branches:
       - main
   pull_request:
+    # `edited` so a PR-title change is re-checked by the lint job.
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history so gitleaks can scan past commits.
+          fetch-depth: 0
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@1.91.0
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install tools (mise)
+        uses: jdx/mise-action@v3
+
+      - name: Format (rustfmt)
+        run: cargo fmt --all --check
+
+      - name: Lint (clippy)
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Format (dprint)
+        run: mise exec -- dprint check
+
+      - name: Pinned tool versions (no "latest")
+        run: |
+          if grep -nE "=[[:space:]]*['\"]latest['\"]" mise.toml; then
+            echo "Pin the tool version in mise.toml; 'latest' is not allowed."
+            exit 1
+          fi
+
+      - name: Secret scan (gitleaks)
+        run: mise exec -- gitleaks git --no-banner --redact
+
+      - name: Conventional PR title (commitlint)
+        if: github.event_name == 'pull_request'
+        env:
+          # Pass via env, never inline, to avoid shell injection.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: printf '%s' "$PR_TITLE" | mise exec -- commitlint
+
   test:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,6 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
-
 jobs:
   # Single deploy job since we're just deploying
   deploy:

--- a/.lefthookrc
+++ b/.lefthookrc
@@ -1,0 +1,6 @@
+# Sourced by lefthook before running pre-commit commands.
+# Commits from editors/GUIs often run with a stripped PATH, so make the
+# toolchains reachable here once instead of in every command:
+#   - cargo: rustup's bin dir
+#   - mise (and the dprint it manages): mise's bin dir + shims
+export PATH="$HOME/.cargo/bin:$HOME/.local/share/mise/shims:$HOME/.local/bin:$PATH"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,7 @@ cargo test --test runner
 ### Testing Patterns
 
 The project uses fixture-based testing extensively:
+
 - Test fixtures in `tests/fixtures/` contain various firepit.yml configurations
 - Integration tests in `tests/runner.rs` and `tests/config.rs`
 - Use `rstest` for parameterized tests
@@ -103,7 +104,7 @@ The project uses fixture-based testing extensively:
 ### Key Configuration Concepts
 
 - **Task Dependencies**: Use `depends_on` for sequential execution
-- **Services**: Long-running tasks with health checks and restart policies  
+- **Services**: Long-running tasks with health checks and restart policies
 - **Variables**: Template variables for dynamic configuration
 - **Environment**: Environment variables and dotenv file support
 - **File Watching**: Input/output file patterns for incremental builds

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,10 +1,12 @@
 // Conventional Commits enforcement for commitlint.
 //
-// The rules below mirror @commitlint/config-conventional. They are inlined
-// rather than pulled in via `extends` because commitlint and the preset are
-// installed under separate mise (npm backend) prefixes, so commitlint cannot
-// resolve the preset package at runtime. Keeping the rules here avoids a
-// node_modules / package.json in this Rust repo.
+// The rules below mirror @commitlint/config-conventional (v21.1.0):
+// https://github.com/conventional-changelog/commitlint/blob/v21.1.0/@commitlint/config-conventional/src/index.ts
+//
+// They are inlined rather than pulled in via `extends` because commitlint and
+// the preset are installed under separate mise (npm backend) prefixes, so
+// commitlint cannot resolve the preset package at runtime. Keeping the rules
+// here avoids a node_modules / package.json in this Rust repo.
 export default {
   rules: {
     "body-leading-blank": [1, "always"],

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,0 +1,44 @@
+// Conventional Commits enforcement for commitlint.
+//
+// The rules below mirror @commitlint/config-conventional. They are inlined
+// rather than pulled in via `extends` because commitlint and the preset are
+// installed under separate mise (npm backend) prefixes, so commitlint cannot
+// resolve the preset package at runtime. Keeping the rules here avoids a
+// node_modules / package.json in this Rust repo.
+export default {
+  rules: {
+    "type-enum": [
+      2,
+      "always",
+      [
+        "build",
+        "chore",
+        "ci",
+        "docs",
+        "feat",
+        "fix",
+        "perf",
+        "refactor",
+        "revert",
+        "style",
+        "test",
+      ],
+    ],
+    "type-case": [2, "always", "lower-case"],
+    "type-empty": [2, "never"],
+    "scope-case": [2, "always", "lower-case"],
+    "subject-empty": [2, "never"],
+    "subject-full-stop": [2, "never", "."],
+    "subject-case": [
+      2,
+      "never",
+      ["sentence-case", "start-case", "pascal-case", "upper-case"],
+    ],
+    "header-max-length": [2, "always", 100],
+    "header-trim": [2, "always"],
+    "body-leading-blank": [1, "always"],
+    "body-max-line-length": [2, "always", 100],
+    "footer-leading-blank": [1, "always"],
+    "footer-max-line-length": [2, "always", 100],
+  },
+};

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -7,6 +7,23 @@
 // node_modules / package.json in this Rust repo.
 export default {
   rules: {
+    "body-leading-blank": [1, "always"],
+    "body-max-line-length": [2, "always", 100],
+    "footer-leading-blank": [1, "always"],
+    "footer-max-line-length": [2, "always", 100],
+    "header-max-length": [2, "always", 100],
+    "header-trim": [2, "always"],
+    // Not part of @commitlint/config-conventional; placed in alphabetical order.
+    "scope-case": [2, "always", "lower-case"],
+    "subject-case": [
+      2,
+      "never",
+      ["sentence-case", "start-case", "pascal-case", "upper-case"],
+    ],
+    "subject-empty": [2, "never"],
+    "subject-full-stop": [2, "never", "."],
+    "type-case": [2, "always", "lower-case"],
+    "type-empty": [2, "never"],
     "type-enum": [
       2,
       "always",
@@ -24,21 +41,5 @@ export default {
         "test",
       ],
     ],
-    "type-case": [2, "always", "lower-case"],
-    "type-empty": [2, "never"],
-    "scope-case": [2, "always", "lower-case"],
-    "subject-empty": [2, "never"],
-    "subject-full-stop": [2, "never", "."],
-    "subject-case": [
-      2,
-      "never",
-      ["sentence-case", "start-case", "pascal-case", "upper-case"],
-    ],
-    "header-max-length": [2, "always", 100],
-    "header-trim": [2, "always"],
-    "body-leading-blank": [1, "always"],
-    "body-max-line-length": [2, "always", 100],
-    "footer-leading-blank": [1, "always"],
-    "footer-max-line-length": [2, "always", 100],
   },
 };

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -15,7 +15,7 @@ const recs = {
 };
 
 // Using asciinema's inline player for video playback.
-// Since script tags cannot be directly embedded in Markdown, 
+// Since script tags cannot be directly embedded in Markdown,
 // we dynamically generate and embed script tags in onMounted
 onMounted(() => {
   for (const [k, v] of Object.entries(recs)) {

--- a/dprint.json
+++ b/dprint.json
@@ -8,7 +8,11 @@
   "yaml": {
   },
   "excludes": [
-    "workflows/release.yml"
+    ".github/workflows/release.yml",
+    "CHANGELOG.md",
+    "schema.json",
+    "docs/schema-body.md",
+    "examples/**"
   ],
   "plugins": [
     "https://plugins.dprint.dev/json-0.19.4.wasm",

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -25,6 +25,12 @@ pre-commit:
       glob: "*.{json,jsonc,md,markdown,toml,yaml,yml}"
       run: mise exec -- dprint check {staged_files}
       fail_text: "Files are not formatted. Run: dprint fmt"
+    mise-pinned:
+      # Tool versions must be pinned; "latest" is not allowed in mise.toml.
+      glob: "mise.toml"
+      run: |
+        grep -nE "=[[:space:]]*['\"]latest['\"]" {staged_files} && exit 1 || exit 0
+      fail_text: "Pin the tool version in mise.toml; 'latest' is not allowed."
 
 commit-msg:
   commands:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -7,21 +7,21 @@
 # pre-commit runs format & lint checks (check-only; nothing is auto-modified).
 # Fix locally with: cargo fmt --all && dprint fmt
 #
-# Commits from editors/GUIs often run with a stripped PATH, so each command
-# makes sure its toolchain is reachable: cargo from the rustup bin dir, and
-# the mise-managed dprint via `mise exec`.
+# PATH for the toolchains (cargo, mise/dprint) is set once in .lefthookrc,
+# which is sourced before the commands run.
+rc: .lefthookrc
 pre-commit:
   parallel: true
   commands:
     rustfmt:
       glob: "*.rs"
-      run: PATH="$HOME/.cargo/bin:$PATH" cargo fmt --all --check
+      run: cargo fmt --all --check
       fail_text: "Rust code is not formatted. Run: cargo fmt --all"
     clippy:
       glob: "*.rs"
-      run: PATH="$HOME/.cargo/bin:$PATH" cargo clippy --all-targets -- -D warnings
+      run: cargo clippy --all-targets -- -D warnings
       fail_text: "Clippy found issues. Fix the warnings above."
     dprint:
       glob: "*.{json,jsonc,md,markdown,toml,yaml,yml}"
-      run: PATH="$HOME/.local/bin:$PATH" mise exec -- dprint check {staged_files}
+      run: mise exec -- dprint check {staged_files}
       fail_text: "Files are not formatted. Run: dprint fmt"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -18,7 +18,14 @@ pre-commit:
       run: cargo fmt --all --check
       fail_text: "Rust code is not formatted. Run: cargo fmt --all"
     clippy:
-      glob: "*.rs"
+      # Run on any Rust build input, not just *.rs: dependency, feature,
+      # toolchain or rustflags changes can all change clippy results.
+      glob:
+        - "*.rs"
+        - "Cargo.toml"
+        - "Cargo.lock"
+        - "rust-toolchain.toml"
+        - ".cargo/config.toml"
       run: cargo clippy --all-targets -- -D warnings
       fail_text: "Clippy found issues. Fix the warnings above."
     dprint:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -31,6 +31,10 @@ pre-commit:
       run: |
         grep -nE "=[[:space:]]*['\"]latest['\"]" {staged_files} && exit 1 || exit 0
       fail_text: "Pin the tool version in mise.toml; 'latest' is not allowed."
+    gitleaks:
+      # Scan staged changes for committed secrets.
+      run: mise exec -- gitleaks git --staged --no-banner --redact
+      fail_text: "Potential secret detected. Remove it before committing."
 
 commit-msg:
   commands:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,27 @@
+# Lefthook configuration
+# Docs: https://lefthook.dev/configuration/
+#
+# Enable on a fresh clone with:
+#   mise install && lefthook install
+#
+# pre-commit runs format & lint checks (check-only; nothing is auto-modified).
+# Fix locally with: cargo fmt --all && dprint fmt
+#
+# Commits from editors/GUIs often run with a stripped PATH, so each command
+# makes sure its toolchain is reachable: cargo from the rustup bin dir, and
+# the mise-managed dprint via `mise exec`.
+pre-commit:
+  parallel: true
+  commands:
+    rustfmt:
+      glob: "*.rs"
+      run: PATH="$HOME/.cargo/bin:$PATH" cargo fmt --all --check
+      fail_text: "Rust code is not formatted. Run: cargo fmt --all"
+    clippy:
+      glob: "*.rs"
+      run: PATH="$HOME/.cargo/bin:$PATH" cargo clippy --all-targets -- -D warnings
+      fail_text: "Clippy found issues. Fix the warnings above."
+    dprint:
+      glob: "*.{json,jsonc,md,markdown,toml,yaml,yml}"
+      run: PATH="$HOME/.local/bin:$PATH" mise exec -- dprint check {staged_files}
+      fail_text: "Files are not formatted. Run: dprint fmt"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -25,3 +25,9 @@ pre-commit:
       glob: "*.{json,jsonc,md,markdown,toml,yaml,yml}"
       run: mise exec -- dprint check {staged_files}
       fail_text: "Files are not formatted. Run: dprint fmt"
+
+commit-msg:
+  commands:
+    commitlint:
+      run: mise exec -- commitlint --edit {1}
+      fail_text: "Commit message must follow Conventional Commits (e.g. 'feat: ...')."

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
 "node" = "24.11.1"
 "github:axodotdev/cargo-dist" = "0.30.4"
-"cargo:git-cliff" = "2.13.1"
+"github:orhun/git-cliff" = "2.13.1"
 "cargo:cargo-edit" = "0.13.10"
 lefthook = "2.1.9"
 dprint = "0.54.0"

--- a/mise.toml
+++ b/mise.toml
@@ -5,9 +5,12 @@
 "cargo:cargo-edit" = "0.13.10"
 "lefthook" = "2.1.9"
 "dprint" = "0.54.0"
-# npm backend tools wait out a 7-day cooldown before a freshly published
-# version (and its transitive deps) is installed, as a supply-chain guard.
-"npm:@commitlint/cli" = { version = "21.1.0", minimum_release_age = "7d" }
+"npm:@commitlint/cli" = "21.1.0"
+
+[settings]
+# Tools wait out a 7-day cooldown before a freshly published version
+# (and, for npm, its transitive deps) is installed — a supply-chain guard.
+minimum_release_age = "7d"
 
 [hooks]
 # Install the git hooks right after `mise install` so contributors don't have

--- a/mise.toml
+++ b/mise.toml
@@ -3,9 +3,11 @@
 "github:axodotdev/cargo-dist" = "0.30.4"
 "github:orhun/git-cliff" = "2.13.1"
 "cargo:cargo-edit" = "0.13.10"
-lefthook = "2.1.9"
-dprint = "0.54.0"
-"npm:@commitlint/cli" = "21.1.0"
+"lefthook" = "2.1.9"
+"dprint" = "0.54.0"
+# npm backend tools wait out a 7-day cooldown before a freshly published
+# version (and its transitive deps) is installed, as a supply-chain guard.
+"npm:@commitlint/cli" = { version = "21.1.0", minimum_release_age = "7d" }
 
 [settings]
 # Required for the [hooks] section below.

--- a/mise.toml
+++ b/mise.toml
@@ -9,10 +9,6 @@
 # version (and its transitive deps) is installed, as a supply-chain guard.
 "npm:@commitlint/cli" = { version = "21.1.0", minimum_release_age = "7d" }
 
-[settings]
-# Required for the [hooks] section below.
-experimental = true
-
 [hooks]
 # Install the git hooks right after `mise install` so contributors don't have
 # to remember to run `lefthook install` manually.

--- a/mise.toml
+++ b/mise.toml
@@ -5,7 +5,7 @@
 "cargo:cargo-edit" = "0.13.10"
 lefthook = "2.1.9"
 dprint = "0.54.0"
-"npm:@commitlint/cli" = "latest"
+"npm:@commitlint/cli" = "21.1.0"
 
 [settings]
 # Required for the [hooks] section below.

--- a/mise.toml
+++ b/mise.toml
@@ -6,6 +6,7 @@
 "lefthook" = "2.1.9"
 "dprint" = "0.54.0"
 "npm:@commitlint/cli" = "21.1.0"
+"github:gitleaks/gitleaks" = "8.30.1"
 
 [settings]
 # Tools wait out a 7-day cooldown before a freshly published version

--- a/mise.toml
+++ b/mise.toml
@@ -5,3 +5,12 @@
 "cargo:cargo-edit" = "0.13.10"
 lefthook = "2.1.9"
 dprint = "0.54.0"
+
+[settings]
+# Required for the [hooks] section below.
+experimental = true
+
+[hooks]
+# Install the git hooks right after `mise install` so contributors don't have
+# to remember to run `lefthook install` manually.
+postinstall = "lefthook install"

--- a/mise.toml
+++ b/mise.toml
@@ -5,6 +5,7 @@
 "cargo:cargo-edit" = "0.13.10"
 lefthook = "2.1.9"
 dprint = "0.54.0"
+"npm:@commitlint/cli" = "latest"
 
 [settings]
 # Required for the [hooks] section below.

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
 "node" = "24.11.1"
 "github:axodotdev/cargo-dist" = "0.30.4"
-"cargo:git-cliff" = "latest"
-"cargo:cargo-edit" = "latest"
-lefthook = "latest"
-dprint = "latest"
+"cargo:git-cliff" = "2.13.1"
+"cargo:cargo-edit" = "0.13.10"
+lefthook = "2.1.9"
+dprint = "0.54.0"

--- a/mise.toml
+++ b/mise.toml
@@ -3,3 +3,5 @@
 "github:axodotdev/cargo-dist" = "0.30.4"
 "cargo:git-cliff" = "latest"
 "cargo:cargo-edit" = "latest"
+lefthook = "latest"
+dprint = "latest"

--- a/src/app/command.rs
+++ b/src/app/command.rs
@@ -262,11 +262,8 @@ impl AppCommandChannel {
     }
 
     pub fn send(&self, event: AppCommand) {
-        match self.tx.send(event) {
-            Err(e) => {
-                warn!("Task {:?} failed to send {} event: {:?}", self.name, e.0.as_ref(), e);
-            }
-            Ok(_) => {}
+        if let Err(e) = self.tx.send(event) {
+            warn!("Task {:?} failed to send {} event: {:?}", self.name, e.0.as_ref(), e);
         }
     }
 
@@ -359,15 +356,15 @@ impl TaskResult {
 
     pub fn short_message(&self) -> String {
         match self {
-            TaskResult::Success => format!("Success"),
+            TaskResult::Success => "Success".to_string(),
             TaskResult::Failure(code) => format!("Failed with exit code {code}"),
-            TaskResult::UpToDate => format!("Up-to-date"),
-            TaskResult::BadDeps => format!("Dependency task failed"),
-            TaskResult::Stopped => format!("Stopped"),
-            TaskResult::NotReady => format!("Service not ready"),
-            TaskResult::Reloading => format!("Service is reloading..."),
-            TaskResult::Error => format!("Error"),
-            TaskResult::Unknown => format!("Unknown"),
+            TaskResult::UpToDate => "Up-to-date".to_string(),
+            TaskResult::BadDeps => "Dependency task failed".to_string(),
+            TaskResult::Stopped => "Stopped".to_string(),
+            TaskResult::NotReady => "Service not ready".to_string(),
+            TaskResult::Reloading => "Service is reloading...".to_string(),
+            TaskResult::Error => "Error".to_string(),
+            TaskResult::Unknown => "Unknown".to_string(),
         }
     }
 
@@ -381,7 +378,7 @@ impl TaskResult {
             TaskResult::NotReady => format!("Service task {:?} is terminated because it did not become ready", name),
             TaskResult::Reloading => format!("Service task {:?} is reloading...", name),
             TaskResult::Error => format!("Task {:?} in not run because of an error during execution", name),
-            TaskResult::Unknown => format!("Unknown"),
+            TaskResult::Unknown => "Unknown".to_string(),
         }
     }
 }

--- a/src/app/cui/mod.rs
+++ b/src/app/cui/mod.rs
@@ -35,7 +35,7 @@ pub struct CuiApp {
 
 impl CuiApp {
     pub fn new(
-        target_tasks: &Vec<String>,
+        target_tasks: &[String],
         labels: &HashMap<String, String>,
         quit_on_done: bool,
         fail_fast: bool,
@@ -47,7 +47,7 @@ impl CuiApp {
             command_tx,
             command_rx,
             signal_handler: SignalHandler::infer()?,
-            target_tasks: target_tasks.clone(),
+            target_tasks: target_tasks.to_vec(),
             labels: labels.clone(),
             fail_fast,
             quit_on_done,
@@ -98,7 +98,7 @@ impl CuiApp {
         }
 
         info!("App is exiting");
-        Ok(ret?)
+        ret
     }
 
     pub async fn run_inner(&mut self) -> anyhow::Result<i32> {
@@ -115,17 +115,18 @@ impl CuiApp {
                         .write_all(output.as_slice())
                         .context("failed to write to stdout")?;
                 }
-                AppCommand::FinishTask { task, result, datetime } => {
+                AppCommand::FinishTask {
+                    task,
+                    result,
+                    datetime: _,
+                } => {
                     debug!("Task {:?} finished", task);
 
                     if result.is_failure() {
                         failed_tasks.insert(task.clone(), result);
                         eprintln!(
                             "{}",
-                            RED.apply_to(format!(
-                                "{}",
-                                result.long_message(self.labels.get(&task).unwrap_or(&task))
-                            ))
+                            RED.apply_to(result.long_message(self.labels.get(&task).unwrap_or(&task)).to_string())
                         );
                     }
                     tasks_remaining.remove(&task);
@@ -141,7 +142,7 @@ impl CuiApp {
             }
         }
 
-        if failed_tasks.len() > 0 {
+        if !failed_tasks.is_empty() {
             if self.fail_fast {
                 let (task, result) = failed_tasks.iter().next().unwrap();
                 eprintln!();
@@ -178,7 +179,7 @@ impl CuiApp {
             }
         }
 
-        let exit_code = if failed_tasks.len() > 0 { 1 } else { 0 };
+        let exit_code = if !failed_tasks.is_empty() { 1 } else { 0 };
         Ok(exit_code)
     }
 }

--- a/src/app/cui/output.rs
+++ b/src/app/cui/output.rs
@@ -24,12 +24,6 @@ pub struct OutputClient<W> {
     writers: Arc<Mutex<SinkWriters<W>>>,
 }
 
-#[derive(Default)]
-struct Marginals {
-    header: Option<()>,
-    footer: Option<()>,
-}
-
 pub struct OutputWriter<'a, W> {
     logger: &'a OutputClient<W>,
     destination: Destination,
@@ -91,7 +85,7 @@ impl<W: Write> OutputSink<W> {
 impl<W: Write> OutputClient<W> {
     /// A writer that will write to the underlying sink's out writer according
     /// to this client's behavior.
-    pub fn stdout(&self) -> OutputWriter<W> {
+    pub fn stdout(&self) -> OutputWriter<'_, W> {
         OutputWriter {
             logger: self,
             destination: Destination::Stdout,
@@ -101,7 +95,7 @@ impl<W: Write> OutputClient<W> {
 
     /// A writer that will write to the underlying sink's err writer according
     /// to this client's behavior.
-    pub fn stderr(&self) -> OutputWriter<W> {
+    pub fn stderr(&self) -> OutputWriter<'_, W> {
         OutputWriter {
             logger: self,
             destination: Destination::Stderr,
@@ -112,11 +106,7 @@ impl<W: Write> OutputClient<W> {
     /// Consume the client and flush any bytes to the underlying sink if
     /// necessary
     pub fn finish(self) -> io::Result<Option<Vec<u8>>> {
-        let Self {
-            behavior,
-            buffer,
-            writers,
-        } = self;
+        let Self { buffer, .. } = self;
         let buffers = buffer.map(|cell| cell.into_inner().expect("should not poisoned"));
         Ok(buffers.map(|buffers| {
             // TODO: it might be worth the list traversal to calculate length so we do a

--- a/src/app/signal.rs
+++ b/src/app/signal.rs
@@ -27,7 +27,11 @@ pub struct SignalSubscriber(oneshot::Receiver<oneshot::Sender<()>>);
 
 /// SubscriberGuard should be kept until a subscriber is done processing the
 /// signal
-pub struct SubscriberGuard(oneshot::Sender<()>);
+pub struct SubscriberGuard {
+    // Held only for its `Drop`: when this guard is dropped, the sender is
+    // dropped, which signals the signal handler worker that cleanup is done.
+    _callback: oneshot::Sender<()>,
+}
 
 fn get_signal() -> anyhow::Result<impl Future<Output = Option<i32>>> {
     use tokio::signal::unix;
@@ -129,13 +133,6 @@ impl SignalHandler {
         // Receiver is dropped once the worker task completes
         self.close.closed().await;
     }
-
-    // Check if the worker thread is done, only meant to be used for assertions in
-    // testing
-    #[cfg(test)]
-    fn is_done(&self) -> bool {
-        self.close.is_closed()
-    }
 }
 
 impl SignalSubscriber {
@@ -145,7 +142,7 @@ impl SignalSubscriber {
             .0
             .await
             .expect("signal handler worker thread exited without alerting subscribers");
-        SubscriberGuard(callback)
+        SubscriberGuard { _callback: callback }
     }
 }
 

--- a/src/app/tui/clipboard.rs
+++ b/src/app/tui/clipboard.rs
@@ -87,8 +87,14 @@ fn copy_impl(s: &str, provider: &Provider) -> std::io::Result<()> {
                 .stderr(Stdio::null())
                 .spawn()
                 .unwrap();
-            std::io::Write::write_all(&mut child.stdin.as_ref().unwrap(), s.as_bytes())?;
+            // Take stdin so it is closed (dropped) before waiting, and make sure
+            // the child is always reaped even if writing fails.
+            let write_result = {
+                let mut stdin = child.stdin.take().unwrap();
+                std::io::Write::write_all(&mut stdin, s.as_bytes())
+            };
             child.wait()?;
+            write_result?;
         }
 
         Provider::NoOp => (),
@@ -97,4 +103,4 @@ fn copy_impl(s: &str, provider: &Provider) -> std::io::Result<()> {
     Ok(())
 }
 
-pub static PROVIDER: Lazy<Provider> = Lazy::new(|| detect_copy_provider());
+static PROVIDER: Lazy<Provider> = Lazy::new(detect_copy_provider);

--- a/src/app/tui/dialog.rs
+++ b/src/app/tui/dialog.rs
@@ -1,6 +1,6 @@
 use once_cell::sync::Lazy;
 use ratatui::layout::Alignment;
-use ratatui::prelude::{Line, Rect, Span, Style, Stylize, Text};
+use ratatui::prelude::{Line, Rect, Span, Style, Text};
 use ratatui::style::Color;
 use ratatui::widgets::block::{Position, Title};
 use ratatui::widgets::{Block, Borders, Clear, Padding, Paragraph, Wrap};
@@ -52,18 +52,12 @@ pub fn render_quit_dialog(f: &mut Frame, force: bool) {
     // Clear the background
     f.render_widget(Clear, dialog_area);
 
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .padding(Padding::horizontal(2));
+    let block = Block::default().borders(Borders::ALL).padding(Padding::horizontal(2));
 
     let lines = if force {
         vec![Line::from(FORCE_QUIT_TXT)]
     } else {
-        QUIT_LINES
-            .iter()
-            .cloned()
-            .map(|line| Line::from(line))
-            .collect::<Vec<_>>()
+        QUIT_LINES.iter().cloned().map(Line::from).collect::<Vec<_>>()
     };
 
     // Create message paragraph

--- a/src/app/tui/hyperlink.rs
+++ b/src/app/tui/hyperlink.rs
@@ -97,11 +97,7 @@ fn find_urls_in_line(line: &str, row_widths: &[(u16, usize)], urls: &mut Vec<Url
 }
 
 /// Map a display-width range to (row, start_col, end_col) segments
-fn map_to_segments(
-    display_start: usize,
-    display_width: usize,
-    row_widths: &[(u16, usize)],
-) -> Vec<UrlSegment> {
+fn map_to_segments(display_start: usize, display_width: usize, row_widths: &[(u16, usize)]) -> Vec<UrlSegment> {
     let display_end = display_start + display_width;
     let mut segments = Vec::new();
     let mut cumulative = 0usize;

--- a/src/app/tui/input.rs
+++ b/src/app/tui/input.rs
@@ -43,7 +43,7 @@ impl InputOptions<'_> {
     }
 
     pub fn on_pane(&self) -> bool {
-        matches!(self.focus, LayoutSections::Pane { .. })
+        matches!(self.focus, LayoutSections::Pane)
     }
 }
 
@@ -150,7 +150,10 @@ impl InputHandler {
                 } else if num_clicks == 2 {
                     self.is_single_click = false;
                     debug!("Double-clicked: word selection");
-                    Some(AppCommand::WordSelection { rows: row, cols: column })
+                    Some(AppCommand::WordSelection {
+                        rows: row,
+                        cols: column,
+                    })
                 } else {
                     self.is_single_click = false;
                     debug!("Triple-clicked: line selection");

--- a/src/app/tui/lib.rs
+++ b/src/app/tui/lib.rs
@@ -25,10 +25,6 @@ impl<T> RingBuffer<T> {
             self.inner.push_back(item);
         }
     }
-
-    pub fn pop(&mut self) -> Option<T> {
-        self.inner.pop_front()
-    }
 }
 
 impl Display for RingBuffer<Instant> {

--- a/src/app/tui/mod.rs
+++ b/src/app/tui/mod.rs
@@ -38,8 +38,8 @@ use ratatui::{
 use std::collections::HashMap;
 use std::io::{self, Stdout, Write};
 use tokio::{sync::mpsc, time::Instant};
-use unicode_width::UnicodeWidthStr;
 use tracing::{debug, error, info};
+use unicode_width::UnicodeWidthStr;
 
 #[derive(Debug, Clone)]
 pub enum LayoutSections {
@@ -78,8 +78,8 @@ pub struct TuiAppState {
 
 impl TuiApp {
     pub fn new(
-        target_tasks: &Vec<String>,
-        dep_tasks: &Vec<String>,
+        target_tasks: &[String],
+        dep_tasks: &[String],
         labels: &HashMap<String, String>,
     ) -> anyhow::Result<Self> {
         let terminal = Self::setup_terminal()?;
@@ -230,7 +230,7 @@ impl TuiApp {
 
     /// Blocking poll for events, will only return None if app handle has been
     /// dropped
-    async fn poll<'a>(&mut self) -> anyhow::Result<Option<AppCommand>> {
+    async fn poll(&mut self) -> anyhow::Result<Option<AppCommand>> {
         let input_closed = self.crossterm_rx.is_closed();
 
         if input_closed {
@@ -292,7 +292,7 @@ impl TuiAppState {
             .with_context(|| format!("task {:?} not found", name))
     }
 
-    fn input_options(&self) -> anyhow::Result<InputOptions> {
+    fn input_options(&self) -> anyhow::Result<InputOptions<'_>> {
         let task = self.active_task()?;
         Ok(InputOptions {
             focus: &self.focus,
@@ -478,8 +478,7 @@ impl TuiAppState {
             .map(|span| span.segments.as_slice());
 
         // Render pane
-        let pane_to_render =
-            TerminalPane::new(&active_task, &self.focus, self.has_sidebar, hovered_segments);
+        let pane_to_render = TerminalPane::new(active_task, &self.focus, self.has_sidebar, hovered_segments);
         f.render_widget(&pane_to_render, pane);
 
         // Render pane scrollbar
@@ -498,7 +497,7 @@ impl TuiAppState {
         }
 
         // Render help dialog
-        if let LayoutSections::Help { scroll, max_scroll } = self.focus {
+        if let LayoutSections::Help { scroll, max_scroll: _ } = self.focus {
             render_help_dialog(f, scroll);
         }
     }
@@ -873,7 +872,7 @@ impl TuiAppState {
                 runner_tx.quit();
             }
             AppCommand::OpenHelp => {
-                let (rect, content_width, content_height) = help_dialog_size(self.size.cols(), self.size.rows());
+                let (rect, _content_width, content_height) = help_dialog_size(self.size.cols(), self.size.rows());
                 self.focus = LayoutSections::Help {
                     scroll: 0,
                     max_scroll: content_height.saturating_sub(rect.height.saturating_sub(2) as usize),

--- a/src/app/tui/pane.rs
+++ b/src/app/tui/pane.rs
@@ -12,18 +12,18 @@ use ratatui::{
 };
 use tui_term::widget::PseudoTerminal;
 
-static STOP_TASK: &'static (&str, &str) = &("[s]", "Stop");
-static RESTART_TASK: &'static (&str, &str) = &("[r]", "Restart");
-static START_INTERACTION: &'static (&str, &str) = &("[Enter]", "Interact");
-static EXIT_INTERACTION: &'static (&str, &str) = &("[Ctrl-z]", "Exit Interaction");
-static START_SEARCH: &'static (&str, &str) = &("[/]", "Search");
-static EXIT_SEARCH: &'static (&str, &str) = &("[Esc]", "Exit Search");
-static COPY_SELECTION: &'static (&str, &str) = &("[c]", "Copy Selection");
-static SHOW_TASKS: &'static (&str, &str) = &("[h]", "Show Tasks");
-static NAVIGATE_SEARCH_RESULT: &'static (&str, &str) = &("[n\u{FF65}N]", "Next/Prev Match");
-static CLEAR_SEARCH_RESULT: &'static (&str, &str) = &("[Esc]", "Clear");
-static QUIT: &'static (&str, &str) = &("[q]", "Quit");
-static HELP: &'static (&str, &str) = &("[?]", "Help");
+static STOP_TASK: &(&str, &str) = &("[s]", "Stop");
+static RESTART_TASK: &(&str, &str) = &("[r]", "Restart");
+static START_INTERACTION: &(&str, &str) = &("[Enter]", "Interact");
+static EXIT_INTERACTION: &(&str, &str) = &("[Ctrl-z]", "Exit Interaction");
+static START_SEARCH: &(&str, &str) = &("[/]", "Search");
+static EXIT_SEARCH: &(&str, &str) = &("[Esc]", "Exit Search");
+static COPY_SELECTION: &(&str, &str) = &("[c]", "Copy Selection");
+static SHOW_TASKS: &(&str, &str) = &("[h]", "Show Tasks");
+static NAVIGATE_SEARCH_RESULT: &(&str, &str) = &("[n\u{FF65}N]", "Next/Prev Match");
+static CLEAR_SEARCH_RESULT: &(&str, &str) = &("[Esc]", "Clear");
+static QUIT: &(&str, &str) = &("[q]", "Quit");
+static HELP: &(&str, &str) = &("[?]", "Help");
 
 pub struct TerminalPane<'a> {
     task: &'a Task,
@@ -51,7 +51,7 @@ impl<'a> TerminalPane<'a> {
         matches!(self.section, LayoutSections::Pane)
     }
 
-    fn right_footer(&self) -> Text {
+    fn right_footer(&self) -> Text<'_> {
         if matches!(self.section, LayoutSections::TaskList { .. }) {
             Text::from(vec![
                 Line::from(key_help_spans(*QUIT)),
@@ -62,7 +62,7 @@ impl<'a> TerminalPane<'a> {
         }
     }
 
-    fn left_footer(&self) -> Text {
+    fn left_footer(&self) -> Text<'_> {
         let mut help_spans = Vec::new();
         let mut search_spans = Vec::new();
         match self.section {
@@ -84,7 +84,7 @@ impl<'a> TerminalPane<'a> {
                 }
                 help_spans.push(key_help_spans(*START_SEARCH));
                 if let Some(search) = s {
-                    if search.matches.len() > 0 {
+                    if !search.matches.is_empty() {
                         help_spans.push(key_help_spans(*NAVIGATE_SEARCH_RESULT));
                         help_spans.push(key_help_spans(*CLEAR_SEARCH_RESULT));
                     }
@@ -108,9 +108,7 @@ impl<'a> TerminalPane<'a> {
         Text::from(vec![
             Line::from(search_spans).left_aligned(),
             Line::from(
-                help_spans
-                    .into_iter()
-                    .intersperse_with(|| vec![Span::raw("  ")])
+                Itertools::intersperse_with(help_spans.into_iter(), || vec![Span::raw("  ")])
                     .flatten()
                     .collect::<Vec<_>>(),
             )
@@ -169,11 +167,7 @@ impl<'a> Widget for &TerminalPane<'a> {
                     let y = inner.y + seg.row;
                     if x < inner.right() && y < inner.bottom() {
                         let cell = buf.get_mut(x, y);
-                        cell.set_style(
-                            Style::default()
-                                .fg(Color::Blue)
-                                .add_modifier(Modifier::UNDERLINED),
-                        );
+                        cell.set_style(Style::default().fg(Color::Blue).add_modifier(Modifier::UNDERLINED));
                     }
                 }
             }

--- a/src/app/tui/table.rs
+++ b/src/app/tui/table.rs
@@ -20,8 +20,8 @@ pub struct TaskTable<'b> {
     section: &'b LayoutSections,
 }
 
-static NAVIGATE_TASKS: &'static (&str, &str) = &("[↑↓]", "Navigate");
-static HIDE_TASKS: &'static (&str, &str) = &("[h] ", "Hide");
+static NAVIGATE_TASKS: &(&str, &str) = &("[↑↓]", "Navigate");
+static HIDE_TASKS: &(&str, &str) = &("[h] ", "Hide");
 static MAX_WIDTH: usize = 40;
 static STATUS_COLUMN_WIDTH: u16 = 3;
 
@@ -44,7 +44,7 @@ impl TaskTable<'_> {
         task_name_width + STATUS_COLUMN_WIDTH + 1
     }
 
-    fn rows(&self) -> Vec<Row> {
+    fn rows(&self) -> Vec<Row<'_>> {
         self.tasks
             .iter()
             .map(|(_, r)| {
@@ -78,7 +78,7 @@ impl TaskTable<'_> {
             .collect()
     }
 
-    fn status_summary(&self) -> Line {
+    fn status_summary(&self) -> Line<'_> {
         // Failure: any task has failed
         if self
             .tasks

--- a/src/app/tui/task.rs
+++ b/src/app/tui/task.rs
@@ -86,7 +86,7 @@ impl Task {
         };
 
         let status = match self.status {
-            TaskStatus::Planned => format!("Waiting"),
+            TaskStatus::Planned => "Waiting".to_string(),
             TaskStatus::Running(_) => format!(
                 "Running, PID: {}, Restart: {}/{}, Reload: {}, Elapsed: {}",
                 pid,

--- a/src/app/tui/term_output.rs
+++ b/src/app/tui/term_output.rs
@@ -20,8 +20,8 @@ impl TerminalOutput {
         }
     }
 
-    pub fn stdin(&self) -> Option<&Box<dyn Write + Send>> {
-        self.stdin.as_ref()
+    pub fn stdin(&self) -> Option<&(dyn Write + Send)> {
+        self.stdin.as_deref()
     }
 
     pub fn stdin_mut(&mut self) -> Option<&mut Box<dyn Write + Send>> {
@@ -40,7 +40,7 @@ impl TerminalOutput {
         self.parser.screen_mut()
     }
 
-    pub fn entire_screen(&self) -> vt100::EntireScreen {
+    pub fn entire_screen(&self) -> vt100::EntireScreen<'_> {
         self.parser.entire_screen()
     }
 
@@ -97,7 +97,7 @@ impl TerminalOutput {
     }
 
     pub fn has_selection(&self) -> bool {
-        self.parser.screen().selected_text().map_or(false, |s| !s.is_empty())
+        self.parser.screen().selected_text().is_some_and(|s| !s.is_empty())
     }
 
     pub fn reset_selection(&mut self) {
@@ -129,10 +129,11 @@ impl TerminalOutput {
                 };
                 match visible_row.get(c) {
                     Some(cell) if cell.is_wide_continuation() => {
-                        c > 0 && visible_row.get(c - 1).is_some_and(|prev| {
-                            let contents = prev.contents();
-                            !contents.is_empty() && !contents.chars().all(|ch| ch.is_whitespace())
-                        })
+                        c > 0
+                            && visible_row.get(c - 1).is_some_and(|prev| {
+                                let contents = prev.contents();
+                                !contents.is_empty() && !contents.chars().all(|ch| ch.is_whitespace())
+                            })
                     }
                     Some(cell) => {
                         let contents = cell.contents();
@@ -190,7 +191,9 @@ impl TerminalOutput {
         };
 
         let (start_row, start_col, end_row, end_col) = selection;
-        self.parser.screen_mut().set_selection(start_row, start_col, end_row, end_col);
+        self.parser
+            .screen_mut()
+            .set_selection(start_row, start_col, end_row, end_col);
     }
 
     pub fn line_selection(&mut self, row: u16) {

--- a/src/bin/firepit-update.rs
+++ b/src/bin/firepit-update.rs
@@ -1,6 +1,6 @@
-use axoupdater::{AxoUpdater, AxoupdateResult};
+use axoupdater::AxoUpdater;
 
-fn main() -> AxoupdateResult<()> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     eprintln!("Checking for updates...");
     match AxoUpdater::new_for("firepit").load_receipt()?.run_sync()? {
         Some(update) => {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -119,7 +119,7 @@ pub async fn run() -> anyhow::Result<i32> {
 
     // Print workspace information if no task specified
     if tasks.is_empty() {
-        print_summary(&root, &children);
+        print_summary(&root, &children)?;
         return Ok(0);
     }
 
@@ -138,7 +138,7 @@ pub async fn run() -> anyhow::Result<i32> {
         args.force,
         args.watch,
         fail_fast,
-        None
+        None,
     )
     .await?;
 
@@ -181,7 +181,7 @@ pub async fn run() -> anyhow::Result<i32> {
     let quit_on_done = !args.watch && root.ui != UI::Tui;
     let runner_fut = tokio_spawn!("runner", async move {
         let result = runner.start(&app_tx, quit_on_done).await;
-        if let Ok(_) = result {
+        if result.is_ok() {
             if let Some(gantt_path) = root.gantt_file {
                 if let Ok(gantt) = runner.gantt() {
                     save_gantt_chart(&gantt, &gantt_path);
@@ -201,7 +201,7 @@ pub async fn run() -> anyhow::Result<i32> {
     exit_code
 }
 
-fn parse_tasks_or_vars(items: &Vec<String>) -> anyhow::Result<(Vec<String>, IndexMap<String, Value>)> {
+fn parse_tasks_or_vars(items: &[String]) -> anyhow::Result<(Vec<String>, IndexMap<String, Value>)> {
     let mut tasks = Vec::new();
     let mut vars = IndexMap::new();
     for item in items.iter() {
@@ -247,17 +247,17 @@ fn print_summary(root: &ProjectConfig, children: &IndexMap<String, ProjectConfig
         lines.extend(project_task_lines(root));
     } else {
         // Show multi project tasks
-        let cwd = getcwd().unwrap_or(path::PathBuf::new());
+        let cwd = getcwd().unwrap_or_default();
         if cwd == root.dir {
             // Show all projects' tasks
-            lines.push(format!("{} {}", BOLD.apply_to("Project:").to_string(), "root"));
+            lines.push(format!("{} {}", BOLD.apply_to("Project:"), "root"));
             lines.extend(project_task_lines(root));
             lines.push("".to_string());
             for c in children.values() {
                 let dir = root.projects.get(&c.name).cloned().unwrap_or_default();
                 lines.push("─".to_string());
-                lines.push(format!("{} {}", BOLD.apply_to("Project:  ").to_string(), c.name));
-                lines.push(format!("{} {}", BOLD.apply_to("Directory:").to_string(), dir));
+                lines.push(format!("{} {}", BOLD.apply_to("Project:  "), c.name));
+                lines.push(format!("{} {}", BOLD.apply_to("Directory:"), dir));
                 lines.extend(project_task_lines(c));
                 lines.push("".to_string());
             }
@@ -265,8 +265,8 @@ fn print_summary(root: &ProjectConfig, children: &IndexMap<String, ProjectConfig
             // Show the current project's tasks only
             if let Some(c) = children.values().find(|v| cwd == v.dir) {
                 let dir = root.projects.get(&c.name).cloned().unwrap_or_default();
-                lines.push(format!("{} {}", BOLD.apply_to("Project:  ").to_string(), c.name));
-                lines.push(format!("{} {}", BOLD.apply_to("Directory:").to_string(), dir));
+                lines.push(format!("{} {}", BOLD.apply_to("Project:  "), c.name));
+                lines.push(format!("{} {}", BOLD.apply_to("Directory:"), dir));
                 lines.extend(project_task_lines(c));
                 lines.push("".to_string());
             }
@@ -317,7 +317,7 @@ fn save_gantt_chart(gantt: &str, path: &str) {
             return;
         }
     };
-    if let Err(e) = file.write_all(gantt.as_bytes()) {
+    if file.write_all(gantt.as_bytes()).is_err() {
         eprintln!("failed to write gantt chart file");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use crate::project::{Env, Task};
+use crate::project::Task;
 use crate::template::ROOT_DIR_CONTEXT_KEY;
 use crate::util::merge_yaml;
 use anyhow::Context;
@@ -304,7 +304,7 @@ impl ProjectConfig {
                 .depends_on
                 .iter()
                 .map(|d| match d {
-                    DependsOnConfig::String(s) => DependsOnConfig::String(Task::qualified_name(&name, s)),
+                    DependsOnConfig::String(s) => DependsOnConfig::String(Task::qualified_name(name, s)),
                     DependsOnConfig::Struct(s) => DependsOnConfig::Struct(DependsOnConfigStruct {
                         task: Task::qualified_name(&data.name, &s.task),
                         vars: s.vars.clone(),
@@ -341,7 +341,7 @@ impl ProjectConfig {
         let mut tera = Tera::default();
         let mut rendered_includes = Vec::new();
         for f in self.includes.iter() {
-            rendered_includes.push(tera.render_str(f, &context)?);
+            rendered_includes.push(tera.render_str(f, context)?);
         }
 
         // Start from empty value
@@ -350,8 +350,8 @@ impl ProjectConfig {
         // Merge included files first
         for incl in rendered_includes.iter() {
             info!("Config file {:?} includes {:?}", self.dir, incl);
-            let path = absolute_or_join(&incl, &self.dir);
-            let (file, _) = Self::open_file(&self.dir.join(&incl))
+            let path = absolute_or_join(incl, &self.dir);
+            let (file, _) = Self::open_file(&self.dir.join(incl))
                 .with_context(|| format!("cannot open included file {:?}", path))?;
             let reader = BufReader::new(file);
             let raw_yaml: Value =
@@ -470,17 +470,14 @@ impl ProjectConfig {
             .iter()
             .map(|d| {
                 if let Some(TaskSelector::Regex(ref pattern)) = d.tasks {
-                    Regex::new(pattern)
-                        .with_context(|| format!("defaults: invalid regex pattern {:?}", pattern))?;
+                    Regex::new(pattern).with_context(|| format!("defaults: invalid regex pattern {:?}", pattern))?;
                 }
                 Ok(DefaultsConfig {
                     depends_on: d
                         .depends_on
                         .iter()
                         .map(|dep| match dep {
-                            DependsOnConfig::String(s) => {
-                                DependsOnConfig::String(Task::qualified_name(&self.name, s))
-                            }
+                            DependsOnConfig::String(s) => DependsOnConfig::String(Task::qualified_name(&self.name, s)),
                             DependsOnConfig::Struct(s) => DependsOnConfig::Struct(DependsOnConfigStruct {
                                 task: Task::qualified_name(&self.name, &s.task),
                                 vars: s.vars.clone(),
@@ -652,25 +649,24 @@ impl TaskConfig {
         format!("{}#{}", self.project, self.orig_name)
     }
 
-    pub fn working_dir_path(&self, dir: &PathBuf) -> PathBuf {
+    pub fn working_dir_path(&self, dir: &Path) -> PathBuf {
         match self.working_dir.clone() {
             Some(wd) => absolute_or_join(&wd, dir),
-            None => dir.clone(),
+            None => dir.to_path_buf(),
         }
     }
 
-    pub fn env_file_paths(&self, dir: &PathBuf) -> Vec<PathBuf> {
+    pub fn env_file_paths(&self, dir: &Path) -> Vec<PathBuf> {
         self.env_files.iter().map(|f| absolute_or_join(f, dir)).collect()
     }
 
-    pub fn input_paths(&self, dir: &PathBuf) -> Vec<PathBuf> {
+    pub fn input_paths(&self, dir: &Path) -> Vec<PathBuf> {
         self.inputs.iter().map(|f| absolute_or_join(f, dir)).collect()
     }
 
-    pub fn output_paths(&self, dir: &PathBuf) -> Vec<PathBuf> {
+    pub fn output_paths(&self, dir: &Path) -> Vec<PathBuf> {
         self.outputs.iter().map(|f| absolute_or_join(f, dir)).collect()
     }
-
 }
 
 fn absolute_or_join(path: &str, dir: &Path) -> PathBuf {
@@ -686,7 +682,7 @@ fn absolute_or_join(path: &str, dir: &Path) -> PathBuf {
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(untagged)]
 pub enum VarsConfig {
-    Dynamic(DynamicVars),
+    Dynamic(Box<DynamicVars>),
     Static(JsonValue),
 }
 
@@ -718,14 +714,14 @@ pub struct DynamicVars {
 }
 
 impl DynamicVars {
-    pub fn env_file_paths(&self, dir: &PathBuf) -> Vec<PathBuf> {
+    pub fn env_file_paths(&self, dir: &Path) -> Vec<PathBuf> {
         self.env_files.iter().map(|f| absolute_or_join(f, dir)).collect()
     }
 
-    pub fn working_dir_path(&self, dir: &PathBuf) -> PathBuf {
+    pub fn working_dir_path(&self, dir: &Path) -> PathBuf {
         match self.working_dir.clone() {
             Some(wd) => absolute_or_join(&wd, dir),
-            None => dir.clone(),
+            None => dir.to_path_buf(),
         }
     }
 }
@@ -854,7 +850,7 @@ pub struct ExecProbeConfig {
 }
 
 impl ExecProbeConfig {
-    pub fn working_dir_path(&self, dir: &PathBuf) -> PathBuf {
+    pub fn working_dir_path(&self, dir: &Path) -> PathBuf {
         match self.working_dir.clone() {
             Some(wd) => {
                 let wd = Path::new(&wd);
@@ -864,11 +860,11 @@ impl ExecProbeConfig {
                     dir.join(wd)
                 }
             }
-            None => dir.clone(),
+            None => dir.to_path_buf(),
         }
     }
 
-    pub fn env_files_paths(&self, dir: &PathBuf) -> Vec<PathBuf> {
+    pub fn env_files_paths(&self, dir: &Path) -> Vec<PathBuf> {
         self.env_files
             .iter()
             .map(|f| {
@@ -900,7 +896,7 @@ pub fn default_healthcheck_start_period() -> u64 {
 #[serde(untagged)]
 pub enum ServiceConfig {
     Bool(bool),
-    Struct(ServiceConfigStruct),
+    Struct(Box<ServiceConfigStruct>),
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -20,7 +20,7 @@ pub fn panic_handler(panic_info: &std::panic::PanicHookInfo) {
     let report_message = if let Some(backtrace) = report.serialize() {
         format!("Backtrace: \n{backtrace}\n")
     } else {
-        format!("Unable to serialize backtrace.")
+        "Unable to serialize backtrace.".to_string()
     };
     eprintln!("Oops! {} has crashed. {}", name, report_message);
 

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -2,7 +2,6 @@ use crate::log::OutputCollector;
 use crate::process::{Child, ChildExit, Command, ProcessManager};
 use crate::project::Env;
 use crate::PROBE_STOP_TIMEOUT;
-use anyhow::Context;
 use regex::Regex;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -19,18 +18,13 @@ pub enum Probe {
 
 #[derive(Debug, Clone)]
 pub struct LogLineProbe {
-    name: String,
     regex: Regex,
     timeout: u64,
 }
 
 impl LogLineProbe {
-    pub fn new(name: &str, regex: Regex, timeout: u64) -> Self {
-        Self {
-            name: name.to_string(),
-            regex,
-            timeout,
-        }
+    pub fn new(regex: Regex, timeout: u64) -> Self {
+        Self { regex, timeout }
     }
 
     pub async fn run(
@@ -86,6 +80,9 @@ pub struct ExecProbe {
 }
 
 impl ExecProbe {
+    // Public constructor mirroring the exec health-check config fields; a builder
+    // refactor would change the public API without real benefit.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         name: &str,
         command: &str,
@@ -150,10 +147,7 @@ impl ExecProbe {
                     let success = match exit {
                         Ok(Some(exit_status)) => {
                             info!("Probe finished with exit code {:?}.\noutput: {:?}", exit_status, output_collector.take_output());
-                            match exit_status {
-                                ChildExit::Finished(Some(code)) if code == 0 => true,
-                                _ => false
-                            }
+                            matches!(exit_status, ChildExit::Finished(Some(0)))
                         },
                         Ok(None) => anyhow::bail!("unable to determine why probe exited"),
                         Err(e) => anyhow::bail!("error while waiting probe: {:?}", e),
@@ -220,7 +214,7 @@ mod test {
     #[tokio::test]
     async fn test_log_line_probe_succeeds() {
         setup();
-        let probe = LogLineProbe::new("test", Regex::new("test").unwrap(), 1);
+        let probe = LogLineProbe::new(Regex::new("test").unwrap(), 1);
         let (log_tx, log_rx) = mpsc::unbounded_channel();
         let (cancel_tx, cancel_rx) = watch::channel(());
 
@@ -230,13 +224,13 @@ mod test {
         // log line matches and succeed
         let result = probe.run(log_rx, cancel_rx).await;
 
-        assert_eq!(result.unwrap(), true);
+        assert!(result.unwrap());
     }
 
     #[tokio::test]
     async fn test_log_line_probe_timeout() {
         setup();
-        let probe = LogLineProbe::new("test", Regex::new("test").unwrap(), 1);
+        let probe = LogLineProbe::new(Regex::new("test").unwrap(), 1);
         let (log_tx, log_rx) = mpsc::unbounded_channel();
         let (cancel_tx, cancel_rx) = watch::channel(());
 
@@ -244,13 +238,13 @@ mod test {
 
         let result = probe.run(log_rx, cancel_rx).await;
 
-        assert_eq!(result.unwrap(), false);
+        assert!(!(result.unwrap()));
     }
 
     #[tokio::test]
     async fn test_log_line_probe_canceled() {
         setup();
-        let probe = LogLineProbe::new("test", Regex::new("test").unwrap(), 1);
+        let probe = LogLineProbe::new(Regex::new("test").unwrap(), 1);
         let (log_tx, log_rx) = mpsc::unbounded_channel();
         let (cancel_tx, cancel_rx) = watch::channel(());
 
@@ -259,7 +253,7 @@ mod test {
 
         let result = probe.run(log_rx, cancel_rx).await;
 
-        assert_eq!(result.unwrap(), false);
+        assert!(!(result.unwrap()));
     }
 
     #[tokio::test]
@@ -281,7 +275,7 @@ mod test {
 
         let result = probe.run(cancel_rx).await;
 
-        assert_eq!(result.unwrap(), true);
+        assert!(result.unwrap());
     }
 
     #[tokio::test]
@@ -303,7 +297,7 @@ mod test {
 
         let result = probe.run(cancel_rx).await;
 
-        assert_eq!(result.unwrap(), false);
+        assert!(!(result.unwrap()));
     }
 
     #[tokio::test]
@@ -325,7 +319,7 @@ mod test {
 
         let result = probe.run(cancel_rx).await;
 
-        assert_eq!(result.unwrap(), false);
+        assert!(!(result.unwrap()));
     }
 
     #[tokio::test]
@@ -348,6 +342,6 @@ mod test {
         cancel_tx.send(());
         let result = probe.run(cancel_rx).await;
 
-        assert_eq!(result.unwrap(), false);
+        assert!(!(result.unwrap()));
     }
 }

--- a/src/process/child.rs
+++ b/src/process/child.rs
@@ -67,16 +67,6 @@ pub enum ShutdownStyle {
     Kill,
 }
 
-/// Child process stopped.
-#[derive(Debug)]
-pub struct ShutdownFailed;
-
-impl From<std::io::Error> for ShutdownFailed {
-    fn from(_: std::io::Error) -> Self {
-        ShutdownFailed
-    }
-}
-
 struct ChildHandle {
     pid: Option<u32>,
     imp: ChildHandleImpl,
@@ -142,7 +132,7 @@ impl ChildHandle {
         };
         let pair = pty_system.openpty(size).map_err(|err| match err.downcast() {
             Ok(err) => err,
-            Err(err) => io::Error::new(io::ErrorKind::Other, err),
+            Err(err) => io::Error::other(err),
         })?;
 
         let controller = pair.master;
@@ -166,7 +156,7 @@ impl ChildHandle {
 
         let child = receiver.spawn_command(command).map_err(|err| match err.downcast() {
             Ok(err) => err,
-            Err(err) => io::Error::new(io::ErrorKind::Other, err),
+            Err(err) => io::Error::other(err),
         })?;
 
         let pid = child.process_id();
@@ -236,7 +226,7 @@ impl ChildHandle {
             ChildHandleImpl::Tokio(child) => child.kill().await,
             ChildHandleImpl::Pty(child) => {
                 let mut killer = child.clone_killer();
-                let pid = self.pid.clone();
+                let pid = self.pid;
                 tokio_spawn_blocking!("kill", { pid = pid }, move || killer.kill())
                     .await
                     .unwrap()
@@ -266,15 +256,6 @@ enum ChildOutput {
         stderr: tokio::process::ChildStderr,
     },
     Pty(Box<dyn Read + Send>),
-}
-
-impl ChildInput {
-    fn concrete(self) -> Option<tokio::process::ChildStdin> {
-        match self {
-            ChildInput::Std(stdin) => Some(stdin),
-            ChildInput::Pty(_) => None,
-        }
-    }
 }
 
 impl fmt::Debug for ChildInput {
@@ -597,7 +578,7 @@ impl Child {
         // TODO: in order to not impose that a stdout_pipe is Send we send the bytes
         // across a channel
         let (byte_tx, mut byte_rx) = mpsc::channel(48);
-        let pid = self.pid.clone();
+        let pid = self.pid;
         tokio_spawn_blocking!("child", { pid = pid }, move || {
             let mut buffer = [0; 1024];
             let mut last_byte = None;
@@ -687,7 +668,7 @@ impl Child {
                     stderr_pipe.write_all(&stderr_buffer)?;
                     stderr_buffer.clear();
                 }
-                status = self.wait(), if !is_exited => {
+                _status = self.wait(), if !is_exited => {
                     trace!("child process exited: {}", self.label());
                     is_exited = true;
                 }
@@ -719,38 +700,6 @@ impl Child {
 
     pub fn label(&self) -> &str {
         &self.label
-    }
-}
-
-struct SharedWriter<W> {
-    inner: Arc<Mutex<W>>,
-}
-
-impl<W> SharedWriter<W> {
-    fn new(writer: W) -> Self {
-        Self {
-            inner: Arc::new(Mutex::new(writer)),
-        }
-    }
-}
-
-impl<W> Clone for SharedWriter<W> {
-    fn clone(&self) -> Self {
-        Self {
-            inner: self.inner.clone(),
-        }
-    }
-}
-
-impl<W: Write> Write for SharedWriter<W> {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let mut writer = self.inner.lock().expect("writer lock poisoned");
-        writer.write(buf)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        let mut writer = self.inner.lock().expect("writer lock poisoned");
-        writer.flush()
     }
 }
 

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -109,16 +109,16 @@ impl ProcessManager {
     }
 
     pub async fn stop(&self) -> Vec<ChildExit> {
-        self.stop_inner(|c| true).await
+        self.stop_inner(|_c| true).await
     }
 
-    async fn stop_inner<F>(&self, filter: F) -> Vec<ChildExit>
+    async fn stop_inner<F>(&self, mut filter: F) -> Vec<ChildExit>
     where
         F: FnMut(&Child) -> bool,
     {
         let mut children = {
             let lock = self.state.lock().await;
-            lock.children.iter().cloned().filter(filter).collect::<Vec<_>>()
+            lock.children.iter().filter(|&x| filter(x)).cloned().collect::<Vec<_>>()
         };
 
         let results = FuturesUnordered::from_iter(children.iter_mut().map(|c| c.stop()))

--- a/src/project.rs
+++ b/src/project.rs
@@ -24,10 +24,13 @@ pub struct Workspace {
 }
 
 impl Workspace {
+    // Public constructor aggregating many independent config inputs; refactoring
+    // into a builder/struct would change the public API without real benefit.
+    #[allow(clippy::too_many_arguments)]
     pub async fn new(
         root_config: &ProjectConfig,
         child_configs: &IndexMap<String, ProjectConfig>,
-        tasks: &Vec<String>,
+        tasks: &[String],
         current_dir: &Path,
         vars: &IndexMap<String, VarsConfig>,
         force: bool,
@@ -58,7 +61,7 @@ impl Workspace {
                         // If not, select all tasks with the name in the child projects.
                         let tasks = match root_config.task(task_name) {
                             Ok(task) => vec![task],
-                            Err(_) => child_configs.values().map(|c| c.task(task_name)).flatten().collect(),
+                            Err(_) => child_configs.values().filter_map(|c| c.task(task_name).ok()).collect(),
                         };
                         if tasks.is_empty() {
                             anyhow::bail!("task {:?} does not exist in any project", task)
@@ -98,7 +101,7 @@ impl Workspace {
             }
         }
 
-        let mut renderer = ConfigRenderer::new(&root_config, &child_configs, &vars, watch);
+        let mut renderer = ConfigRenderer::new(&root_config, &child_configs, vars, watch);
         let (root_config, child_configs) = renderer.render().await?;
         ProjectConfig::validate_multi(&root_config, &child_configs)?;
 
@@ -184,7 +187,7 @@ impl Project {
     pub fn new(name: &str, root: &ProjectConfig) -> anyhow::Result<Project> {
         Ok(Project {
             name: name.to_owned(),
-            tasks: Task::new_multi(name, &root)?,
+            tasks: Task::new_multi(name, root)?,
             dir: root.dir.clone(),
         })
     }
@@ -248,15 +251,21 @@ pub struct Env {
     configs: Vec<EnvConfig>,
 }
 
+impl Default for Env {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Env {
     pub fn new() -> Self {
         Self { configs: Vec::new() }
     }
 
-    pub fn with(&self, env_files: &Vec<PathBuf>, env: &IndexMap<String, String>) -> Self {
+    pub fn with(&self, env_files: &[PathBuf], env: &IndexMap<String, String>) -> Self {
         let mut configs = self.configs.clone();
         configs.push(EnvConfig {
-            env_files: env_files.clone(),
+            env_files: env_files.to_vec(),
             env: env.clone(),
         });
         Self { configs }
@@ -268,11 +277,8 @@ impl Env {
     }
 
     pub fn load(&self) -> anyhow::Result<HashMap<String, String>> {
-        self.configs.iter().fold(Ok(HashMap::new()), |acc, config| {
-            Ok(acc?
-                .into_iter()
-                .chain(config.merged_env()?.into_iter())
-                .collect::<HashMap<_, _>>())
+        self.configs.iter().try_fold(HashMap::new(), |acc, config| {
+            Ok(acc.into_iter().chain(config.merged_env()?).collect::<HashMap<_, _>>())
         })
     }
 }
@@ -288,7 +294,7 @@ impl EnvConfig {
         Ok(self
             .load_env_files()?
             .into_iter()
-            .chain(self.env.clone().into_iter())
+            .chain(self.env.clone())
             .collect::<HashMap<_, _>>())
     }
 
@@ -316,7 +322,7 @@ impl Task {
     pub fn new_multi(project_name: &str, config: &ProjectConfig) -> anyhow::Result<HashMap<String, Task>> {
         let mut ret = HashMap::new();
         for (task_name, task_config) in config.tasks.iter() {
-            let task = Self::new(project_name, &config, task_name, task_config)?;
+            let task = Self::new(project_name, config, task_name, task_config)?;
             ret.insert(task.name.clone(), task);
         }
 
@@ -365,14 +371,14 @@ impl Task {
         let inputs = task_config
             .input_paths(&config.dir)
             .into_iter()
-            .chain(task_config.env_file_paths(&config.dir).into_iter())
+            .chain(task_config.env_file_paths(&config.dir))
             .collect::<Vec<_>>();
 
         // Output files
         let outputs = task_config
             .output_paths(&config.dir)
             .into_iter()
-            .chain(task_config.env_file_paths(&config.dir).into_iter())
+            .chain(task_config.env_file_paths(&config.dir))
             .collect::<Vec<_>>();
 
         // Probes
@@ -384,7 +390,6 @@ impl Task {
                         Some(healthcheck) => match healthcheck {
                             // Log Probe
                             HealthCheckConfig::Log(c) => Probe::LogLine(LogLineProbe::new(
-                                &task_name,
                                 Regex::new(&c.log).with_context(|| format!("invalid regex pattern {:?}", c.log))?,
                                 c.timeout,
                             )),
@@ -467,15 +472,12 @@ impl Task {
     }
 
     pub fn match_inputs(&self, paths: &HashSet<PathBuf>) -> bool {
-        self.inputs
-            .iter()
-            .map(|i| {
-                self.match_glob(i.to_str().unwrap_or(""), paths).unwrap_or_else(|e| {
-                    warn!("{:?}", e);
-                    false
-                })
+        self.inputs.iter().any(|i| {
+            self.match_glob(i.to_str().unwrap_or(""), paths).unwrap_or_else(|e| {
+                warn!("{:?}", e);
+                false
             })
-            .any(|b| b)
+        })
     }
 
     pub fn is_up_to_date(&self) -> bool {
@@ -510,7 +512,7 @@ impl Task {
         input_modified_time < output_modified_time
     }
 
-    fn latest_modified_time(&self, paths: &Vec<PathBuf>) -> u64 {
+    fn latest_modified_time(&self, paths: &[PathBuf]) -> u64 {
         let timestamps = paths
             .iter()
             .map(|p| self.modified_time(p))
@@ -530,7 +532,7 @@ impl Task {
     }
 
     fn modified_time(&self, path: &Path) -> anyhow::Result<Option<u64>> {
-        let metadata = std::fs::metadata(&path).with_context(|| format!("failed to get metadata of {:?}", path))?;
+        let metadata = std::fs::metadata(path).with_context(|| format!("failed to get metadata of {:?}", path))?;
         if !metadata.is_file() {
             return Ok(None);
         }
@@ -542,7 +544,7 @@ impl Task {
         Ok(Some(timestamp))
     }
 
-    fn glob(&self, pattern: &PathBuf) -> anyhow::Result<Vec<PathBuf>> {
+    fn glob(&self, pattern: &Path) -> anyhow::Result<Vec<PathBuf>> {
         let file_name = pattern.file_name().map(|f| f.to_string_lossy());
         let dir_name = pattern.parent();
 

--- a/src/runner/command.rs
+++ b/src/runner/command.rs
@@ -40,11 +40,8 @@ impl RunnerCommandChannel {
     }
 
     fn send(&self, event: RunnerCommand) {
-        match self.tx.send(event) {
-            Err(e) => {
-                warn!("Failed to send {} event: {:?}", e.0.as_ref(), e);
-            }
-            Ok(_) => {}
+        if let Err(e) = self.tx.send(event) {
+            warn!("Failed to send {} event: {:?}", e.0.as_ref(), e);
         }
     }
 }

--- a/src/runner/graph.rs
+++ b/src/runner/graph.rs
@@ -53,16 +53,10 @@ pub enum NodeResult {
 
 impl NodeResult {
     pub fn success(&self) -> bool {
-        match self {
-            NodeResult::Success => true,
-            _ => false,
-        }
+        matches!(self, NodeResult::Success)
     }
     pub fn present(&self) -> bool {
-        match self {
-            NodeResult::None => false,
-            _ => true,
-        }
+        !matches!(self, NodeResult::None)
     }
 }
 
@@ -147,7 +141,7 @@ impl TaskGraph {
         let (visitor_tx, visitor_rx) = broadcast::channel(1024);
 
         // Remaining target tasks
-        let targets_remaining: HashSet<String> = self.targets.iter().map(|s| s.clone()).collect();
+        let targets_remaining: HashSet<String> = self.targets.iter().cloned().collect();
         let targets_remaining = Arc::new(Mutex::new(targets_remaining));
 
         // Run visitor thread for all nodes
@@ -414,7 +408,6 @@ impl TaskGraph {
 
     async fn wait_all_watches(mut receivers: Vec<watch::Receiver<NodeResult>>) -> anyhow::Result<bool> {
         for rx in receivers.iter_mut() {
-            let v = rx.borrow().clone();
             if (*rx.borrow()).present() {
                 if !(*rx.borrow()).success() {
                     return Ok(false);

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -89,7 +89,7 @@ impl TaskRunner {
             self.manager.set_pty_size(pane_size.rows, pane_size.cols).await;
         }
 
-        let ret = self.run(&app_tx, quit_on_done).await;
+        let ret = self.run(app_tx, quit_on_done).await;
 
         if let Err(err) = ret {
             error!("Error: {:?}", err);
@@ -124,7 +124,7 @@ impl TaskRunner {
 
         // Task futures
         let mut task_fut = FuturesUnordered::new();
-        let targets_remaining: HashSet<String> = self.target_tasks.iter().map(|s| s.clone()).collect();
+        let targets_remaining: HashSet<String> = self.target_tasks.iter().cloned().collect();
         let targets_remaining = Arc::new(Mutex::new(targets_remaining));
 
         while !node_rx.is_closed() {
@@ -155,8 +155,8 @@ impl TaskRunner {
                             for task in tasks.iter() {
                                 let end_time =  Local::now();
                                 self.end_times.lock().expect("not poisoned").insert( task.clone(), end_time);
-                                app_tx.clone().with_name(&task).finish_task(TaskResult::Reloading, Some(end_time));
-                                self.manager.stop_by_label(&task).await;
+                                app_tx.clone().with_name(task).finish_task(TaskResult::Reloading, Some(end_time));
+                                self.manager.stop_by_label(task).await;
                             }
                             info!("Stopped tasks");
                             info!("Restarting visitors");
@@ -349,7 +349,7 @@ impl TaskRunner {
                                 }
                             }
                             // If the process finished before the probe, consider it as failed regardless of the result
-                            if let Some(_) = task_result {
+                            if task_result.is_some() {
                                 info!("Task finished before it becomes ready");
                                 if let Err(e) = probe_cancel_tx.send(()) {
                                     warn!("Failed to send cancel probe: {:?}", e)
@@ -431,12 +431,8 @@ impl TaskRunner {
 
     async fn join<T>(futures: &mut FuturesUnordered<JoinHandle<T>>) -> anyhow::Result<()> {
         while let Some(r) = futures.next().await {
-            match r {
-                Ok(_) => match r {
-                    Err(e) => anyhow::bail!("error while waiting futures: {:?}", e),
-                    _ => {}
-                },
-                Err(e) => anyhow::bail!("error while waiting futures: {:?}", e),
+            if let Err(e) = r {
+                anyhow::bail!("error while waiting futures: {:?}", e);
             }
         }
         Ok(())
@@ -497,7 +493,7 @@ impl TaskRunner {
         info!("Process is waiting for output. PID={}", pid);
         let result = match process.wait_with_piped_outputs(app_tx.clone(), app_tx.clone()).await {
             Ok(Some(exit_status)) => match exit_status {
-                ChildExit::Finished(Some(code)) if code == 0 => TaskResult::Success,
+                ChildExit::Finished(Some(0)) => TaskResult::Success,
                 ChildExit::Finished(Some(code)) => TaskResult::Failure(code),
                 ChildExit::Killed | ChildExit::KilledExternal => TaskResult::Stopped,
                 ChildExit::Failed => TaskResult::Unknown,
@@ -516,22 +512,19 @@ impl TaskRunner {
             .lock()
             .expect("not poisoned")
             .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
+            .map(|(k, v)| (k.clone(), *v))
             .collect::<IndexMap<_, _>>();
         let finished_times = self
             .end_times
             .lock()
             .expect("not poisoned")
             .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
+            .map(|(k, v)| (k.clone(), *v))
             .collect::<IndexMap<_, _>>();
 
         let title = self.target_tasks.join(", ");
 
-        let mut gantt = String::from(format!(
-            "gantt\n\ttitle {}\n\tdateFormat x\n\taxisFormat %H:%M:%S\n",
-            title
-        ));
+        let mut gantt = format!("gantt\n\ttitle {}\n\tdateFormat x\n\taxisFormat %H:%M:%S\n", title);
 
         for (task, start_time) in started_times.iter() {
             let end_time = finished_times.get(task);

--- a/src/runner/watcher.rs
+++ b/src/runner/watcher.rs
@@ -35,10 +35,10 @@ pub struct FileWatcherHandle {
 }
 
 impl FileWatcher {
-    pub fn new(tasks: &Vec<Task>, dir: &Path, debounce_duration: Duration) -> FileWatcher {
+    pub fn new(tasks: &[Task], dir: &Path, debounce_duration: Duration) -> FileWatcher {
         FileWatcher {
             inner: Arc::new(Mutex::new(FileWatcherState { is_closing: false })),
-            tasks: tasks.clone(),
+            tasks: tasks.to_vec(),
             dir: dir.to_path_buf(),
             debounce_duration,
         }
@@ -55,22 +55,17 @@ impl FileWatcher {
         // Cancel the file watcher if cancel is sent
         let state = self.inner.clone();
         tokio_spawn!("watcher-canceller", async move {
-            while let Ok(event) = watcher_rx.recv().await {
-                match event {
-                    WatcherCommand::Stop => {
-                        debug!("Stopping watcher");
-                        let mut state = state.lock().expect("not poisoned");
-                        state.is_closing = true;
-                        break;
-                    }
-                }
+            if let Ok(WatcherCommand::Stop) = watcher_rx.recv().await {
+                debug!("Stopping watcher");
+                let mut state = state.lock().expect("not poisoned");
+                state.is_closing = true;
             }
         });
 
         let state = self.inner.clone();
         let tasks = self.tasks.clone();
         let dir = self.dir.clone();
-        let debounce_duration = self.debounce_duration.clone();
+        let debounce_duration = self.debounce_duration;
         let runner_tx = runner_tx.clone();
         let future = std::thread::spawn(move || {
             let _guard = watcher;

--- a/src/template.rs
+++ b/src/template.rs
@@ -12,7 +12,6 @@ use indexmap::IndexMap;
 use serde_json::{Map, Value as JsonValue};
 use serde_yaml::Value;
 use std::collections::HashMap;
-use std::path::PathBuf;
 use tera::Tera;
 use tracing::{debug, info};
 
@@ -47,7 +46,7 @@ impl ProjectConfig {
             .iter()
             .chain(self.vars.iter().filter(|(k, _)| !vars.contains_key(*k)))
         {
-            let rk = tera.render_str(&k, &context)?;
+            let rk = tera.render_str(k, &context)?;
             if !rk.is_empty() {
                 let v = match v {
                     VarsConfig::Dynamic(s) => {
@@ -87,12 +86,12 @@ impl ProjectConfig {
         // Render includes
         let mut rendered_includes = Vec::new();
         for f in config.includes.iter() {
-            rendered_includes.push(tera.render_str(f, &context)?);
+            rendered_includes.push(tera.render_str(f, context)?);
         }
         config.includes = rendered_includes;
 
         // Render working_dir
-        config.working_dir = tera.render_str(&config.working_dir, &context)?;
+        config.working_dir = tera.render_str(&config.working_dir, context)?;
 
         // Render env
         config.env = render_string_map(&config.env, &mut tera, context)?;
@@ -101,7 +100,7 @@ impl ProjectConfig {
         config.env_files = config
             .env_files
             .iter()
-            .map(|f| tera.render_str(f, &context))
+            .map(|f| tera.render_str(f, context))
             .collect::<anyhow::Result<Vec<_>, _>>()?;
 
         // Render tasks
@@ -126,7 +125,7 @@ impl TaskConfig {
 
         // Render task-level vars
         for (k, v) in self.vars.iter() {
-            let rk = tera.render_str(&k, &context)?;
+            let rk = tera.render_str(k, &context)?;
             if !rk.is_empty() {
                 let v = match v {
                     VarsConfig::Dynamic(s) => {
@@ -169,25 +168,25 @@ impl TaskConfig {
 
         // Render label
         if let Some(l) = config.label {
-            config.label = Some(tera.render_str(&l, &context)?);
+            config.label = Some(tera.render_str(&l, context)?);
         }
 
         // Render command
-        config.command = config.command.map(|c| tera.render_str(&c, &context)).transpose()?;
+        config.command = config.command.map(|c| tera.render_str(&c, context)).transpose()?;
 
         // Render working_dir
         config.working_dir = match config.working_dir {
-            Some(w) => Some(tera.render_str(&w, &context)?),
+            Some(w) => Some(tera.render_str(&w, context)?),
             None => None,
         };
 
         // Render env
-        config.env = render_string_map(&config.env, &mut tera, &context)?;
+        config.env = render_string_map(&config.env, &mut tera, context)?;
 
         // Render env_files
         let mut rendered_env_files = Vec::new();
         for f in config.env_files.iter() {
-            rendered_env_files.push(tera.render_str(f, &context)?);
+            rendered_env_files.push(tera.render_str(f, context)?);
         }
         config.env_files = rendered_env_files;
 
@@ -199,16 +198,16 @@ impl TaskConfig {
                         // Log Probe
                         HealthCheckConfig::Log(ref mut c) => {
                             // Render log
-                            c.log = tera.render_str(&c.log, &context)?;
+                            c.log = tera.render_str(&c.log, context)?;
                         }
                         // Exec Probe
                         HealthCheckConfig::Exec(ref mut c) => {
                             // Render command
-                            c.command = tera.render_str(&c.command, &context)?;
+                            c.command = tera.render_str(&c.command, context)?;
 
                             // Render working_dir
                             c.working_dir = match &c.working_dir {
-                                Some(w) => Some(tera.render_str(&w, &context)?),
+                                Some(w) => Some(tera.render_str(w, context)?),
                                 None => None,
                             };
 
@@ -219,7 +218,7 @@ impl TaskConfig {
                             c.env_files = c
                                 .env_files
                                 .iter()
-                                .map(|f| tera.render_str(f, &context))
+                                .map(|f| tera.render_str(f, context))
                                 .collect::<anyhow::Result<Vec<_>, _>>()?;
                         }
                     }
@@ -236,14 +235,14 @@ impl TaskConfig {
         for depends_on in config.depends_on.iter() {
             match depends_on {
                 DependsOnConfig::String(task) => {
-                    let task = tera.render_str(task, &context)?;
+                    let task = tera.render_str(task, context)?;
                     // Ignore if rendered task name is empty
                     if !task.ends_with("#") {
                         rendered_depends_on.push(DependsOnConfig::String(task))
                     }
                 }
                 DependsOnConfig::Struct(dep) => {
-                    let task = tera.render_str(&dep.task, &context)?;
+                    let task = tera.render_str(&dep.task, context)?;
                     // Ignore if rendered task name is empty
                     if !task.ends_with("#") {
                         let vars = render_value_map(&dep.vars, &mut tera, context).await?;
@@ -419,7 +418,7 @@ impl ConfigRenderer {
         contexts: &mut HashMap<String, tera::Context>,
     ) -> anyhow::Result<()> {
         // Get task config
-        let (task_config, project_config) =
+        let (task_config, _project_config) =
             Self::get_task(task_name, root_config, child_configs).context(format!("unknown task {:?}", task_name))?;
         let context = contexts
             .get(task_name)
@@ -616,7 +615,7 @@ async fn render_value(value: &VarsConfig, tera: &mut Tera, context: &tera::Conte
             let command = Command::new(shell.command)
                 .with_args(args)
                 .with_envs(inner.env)
-                .with_current_dir(PathBuf::from(working_dir))
+                .with_current_dir(working_dir)
                 .to_owned();
             let output = execute_command(&command)
                 .await
@@ -645,7 +644,7 @@ async fn execute_command(command: &Command) -> anyhow::Result<String> {
     Ok(match exit {
         Ok(Some(exit_status)) => match exit_status {
             // Trim trailing newline
-            ChildExit::Finished(Some(code)) if code == 0 => output,
+            ChildExit::Finished(Some(0)) => output,
             ChildExit::Finished(Some(code)) => {
                 anyhow::bail!("process exited with non-zero code: {:?}, output: {:?}", code, output)
             }

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -99,5 +99,5 @@ async fn test_multi() {
     );
     assert!(install.depends_on.is_empty());
 
-    let foo = ws.children.get("foo").unwrap().task("foo").unwrap();
+    let _foo = ws.children.get("foo").unwrap().task("foo").unwrap();
 }

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -343,7 +343,7 @@ async fn test_vars_dynamic() {
     let mut outputs = HashMap::new();
     outputs.insert(
         String::from("#foo"),
-        String::from(format!("12345 workflows true foo {}\nA\nB\nC\nD\nE", branch)),
+        format!("12345 workflows true foo {}\nA\nB\nC\nD\nE", branch),
     );
 
     run_task(&path, tasks, stats, Some(outputs), false).await.unwrap();
@@ -580,6 +580,9 @@ async fn run_task_with_vars(
     .await
 }
 
+// Test helper aggregating many independent expectations; a struct refactor
+// would add noise without improving the tests.
+#[allow(clippy::too_many_arguments)]
 async fn run_task_inner(
     path: &Path,
     tasks: Vec<String>,
@@ -593,7 +596,18 @@ async fn run_task_inner(
 ) -> anyhow::Result<()> {
     let path = path::absolute(path)?;
     let (root, children) = ProjectConfig::new_multi(&path)?;
-    let ws = Workspace::new(&root, &children, &tasks, &path, &vars, force, false, Some(false), Some(false)).await?;
+    let ws = Workspace::new(
+        &root,
+        &children,
+        &tasks,
+        &path,
+        &vars,
+        force,
+        false,
+        Some(false),
+        Some(false),
+    )
+    .await?;
     // Create runner
     let mut runner = TaskRunner::new(&ws)?;
     let (app_tx, app_rx) = AppCommandChannel::new();
@@ -621,6 +635,9 @@ async fn run_task_inner(
     Ok(())
 }
 
+// Test helper aggregating many independent expectations; a struct refactor
+// would add noise without improving the tests.
+#[allow(clippy::too_many_arguments)]
 async fn run_task_with_watch<F>(
     path: &Path,
     tasks: Vec<String>,
@@ -663,7 +680,7 @@ async fn run_task_with_watch<F>(
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     // Do something in this closure, ex: create or update files
-    tokio::spawn(async move { f.await });
+    tokio::spawn(f);
 
     // Handle events and assert task statuses
     handle_events(


### PR DESCRIPTION
## Summary

Adds a layered set of guardrails — local git hooks (lefthook) **and** matching
CI enforcement — so formatting, linting, secrets, dependency hygiene and commit
conventions are checked automatically. Also cleans up the existing clippy/rustfmt
violations so everything passes.

## Local hooks (lefthook, auto-installed via mise)

`mise install` runs `lefthook install` (postinstall hook), so contributors get
the hooks without extra steps. PATH for the toolchains is sourced once from
`.lefthookrc` so editor/GUI commits work too.

**pre-commit**
- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings` — runs on any Rust build input
  (`*.rs`, `Cargo.toml`, `Cargo.lock`, `rust-toolchain.toml`, `.cargo/config.toml`)
- `dprint check` (JSON / Markdown / TOML / YAML; generated files excluded)
- mise.toml pinned-version guard (rejects `latest`)
- `gitleaks git --staged` secret scan

**commit-msg**
- `commitlint` (Conventional Commits) using an inline config mirroring
  `@commitlint/config-conventional`

## Tooling (mise)

- Manage `lefthook`, `dprint`, `@commitlint/cli`, `gitleaks` via mise, all pinned
- `git-cliff` switched from the cargo backend to a prebuilt binary (fixes a CI
  install failure where building from source raced rustup downloads)
- `minimum_release_age = "7d"` cooldown on tools as a supply-chain guard

## CI enforcement (`lint` job in ci.yml)

Runs the same checks as the hooks (so they can't be bypassed): rustfmt, clippy,
dprint, the no-`latest` guard, and a gitleaks history scan. Also lints the **PR
title** with commitlint — this repo squash-merges with the PR title as the commit
subject. Token scoped to `contents: read`; PR title passed via env to avoid shell
injection.

## Codebase cleanup

- Resolve ~165 clippy findings (needless borrows, `&Path`/`&[_]` params,
  `matches!`/`if let`, boxed large enum variants, `Default` impls, dead code)
- Real fix: reap the clipboard child process on all paths to avoid a zombie

## Verification
- `cargo clippy --all-targets -- -D warnings`, `cargo fmt --all --check`,
  `cargo test --all --locked`, and repo-wide `dprint check` all pass
- CI (lint + test on ubuntu/macos) is green
