### PR TITLE
feat(cli): forward arguments after -- to tasks via the args variable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,7 +812,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -867,6 +867,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "shell-words",
  "strum",
  "tera",
  "tokio",
@@ -2261,7 +2262,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.8",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2510,7 +2511,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2781,9 +2782,9 @@ dependencies = [
 
 [[package]]
 name = "shell-words"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -2996,7 +2997,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3713,7 +3714,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ schemars = { version = "1.0.0", features = ["indexmap2"] }
 serde = { version = "1.0.214", features = ["derive"] }
 serde_json = "1.0.137"
 serde_yaml = "0.9.34"
+shell-words = "1.1.1"
 strum = "0.26.3"
 tera = "1.20.0"
 tokio = { version = "1.41.1", features = ["full"] }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,7 +9,7 @@ outline: deep
 ## Usage
 
 ```
-fire [OPTIONS] [TASKS]... [VARS]...
+fire [OPTIONS] [TASKS]... [VARS]... [-- <ARGS>...]
 ```
 
 ## Arguments
@@ -21,6 +21,17 @@ One or more tasks to run. Tasks run in parallel by default, respecting dependenc
 ### Vars
 
 Template variables to override. Variable are in "Name=Value" format (e.g. `ENV=prod`, `DEBUG=true`)
+
+### Args
+
+Arguments after `--` are joined with a space and assigned to the `args` template variable, so they can be referenced in task commands as `{{ args }}`.
+
+```
+fire test -- --nocapture my_test
+```
+
+This is an alias for setting `args=...`, so specifying both `args=...` and `-- ...` at the same time is an error.
+See [Passing Arguments](/configuration#passing-arguments) for details.
 
 ## Options
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,12 +24,13 @@ Template variables to override. Variable are in "Name=Value" format (e.g. `ENV=p
 
 ### Args
 
-Arguments after `--` are joined with a space and assigned to the `args` template variable, so they can be referenced in task commands as `{{ args }}`.
+Arguments after `--` are shell-escaped, joined with a space, and assigned to the `args` template variable, so they can be referenced in task commands as `{{ args }}`.
 
 ```
 fire test -- --nocapture my_test
 ```
 
+Embed `{{ args }}` without extra quotes in task commands.
 This is an alias for setting `args=...`, so specifying both `args=...` and `-- ...` at the same time is an error.
 See [Passing Arguments](/configuration#passing-arguments) for details.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -257,7 +257,8 @@ tasks:
 fire test -- --nocapture my_test   # runs: cargo test --nocapture my_test
 ```
 
-Everything after `--` is joined with a space and assigned to `args`.
+Everything after `--` is shell-escaped, joined with a space, and assigned to `args`.
+Embed `{{ args }}` without extra quotes so the shell can interpret the generated quoting correctly.
 Since `--` is just an alias for `args=...`, specifying both at the same time is an error.
 
 Because `args` is an ordinary variable, a dependent task can also set it through `depends_on`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -240,6 +240,45 @@ There are also some built-in variables available for use in templates.
 | `task`         | string              | The task name.                                                         |
 | `watch`        | boolean             | `true` if running in watch mode, `false` otherwise.                    |
 
+### Passing Arguments
+
+The `args` variable is a convenient convention for forwarding command-line arguments to a task.
+Declare it with a default value, reference it in the command, and override it from the CLI using `--`:
+
+```yaml
+tasks:
+  test:
+    vars:
+      args: ""
+    command: cargo test {{ args }}
+```
+
+```
+fire test -- --nocapture my_test   # runs: cargo test --nocapture my_test
+```
+
+Everything after `--` is joined with a space and assigned to `args`.
+Since `--` is just an alias for `args=...`, specifying both at the same time is an error.
+
+Because `args` is an ordinary variable, a dependent task can also set it through `depends_on`.
+The dependency task must already declare the variable (here, `test` declares `args`):
+
+```yaml
+tasks:
+  test:
+    vars:
+      args: ""
+    command: cargo test {{ args }}
+
+  ci:
+    depends_on:
+      - task: test
+        vars:
+          args: "--release" # runs test as: cargo test --release
+```
+
+When a dependency specifies `vars`, that value takes precedence over any value injected globally via `--`.
+
 ## Environment Variables
 
 Environment variables can be defined in the `env` field.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,8 +16,8 @@ use std::io::Write;
 use std::path;
 use tracing::info;
 
-/// Name of the variable that receives the CLI arguments passed after `--`.
-const CLI_ARGS_VAR_NAME: &str = "args";
+/// Name of the variable that receives the task arguments passed after `--`.
+const TASK_ARGS_VAR_NAME: &str = "args";
 
 /// Firepit: Simple task & service runner with a comfortable TUI
 #[derive(Parser, Debug)]
@@ -31,8 +31,8 @@ pub struct Args {
     /// Extra arguments forwarded to tasks.
     /// Everything after `--` is joined with spaces and assigned to the `args` variable,
     /// so it can be referenced in task commands as `{{ args }}`.
-    #[arg(last = true)]
-    pub cli_args: Vec<String>,
+    #[arg(last = true, value_name = "ARGS")]
+    pub task_args: Vec<String>,
 
     /// Working directory
     #[arg(short, long, default_value = ".")]
@@ -101,7 +101,7 @@ pub async fn run() -> anyhow::Result<i32> {
     // Arguments
     let args = Args::parse();
     let dir = path::absolute(&args.dir)?;
-    let (tasks, vars) = parse_tasks_or_vars(&args.tasks_or_vars, &args.cli_args)?;
+    let (tasks, vars) = parse_tasks_or_vars(&args.tasks_or_vars, &args.task_args)?;
     let fail_fast = args.fail_fast();
 
     // Load config files
@@ -212,7 +212,7 @@ pub async fn run() -> anyhow::Result<i32> {
 
 fn parse_tasks_or_vars(
     items: &[String],
-    cli_args: &[String],
+    task_args: &[String],
 ) -> anyhow::Result<(Vec<String>, IndexMap<String, Value>)> {
     let mut tasks = Vec::new();
     let mut vars = IndexMap::new();
@@ -238,14 +238,14 @@ fn parse_tasks_or_vars(
 
     // Forward the arguments after `--` as the `args` variable (space-joined).
     // This is just an alias for setting `args=...`, so specifying both is ambiguous and rejected.
-    if !cli_args.is_empty() {
-        if vars.contains_key(CLI_ARGS_VAR_NAME) {
+    if !task_args.is_empty() {
+        if vars.contains_key(TASK_ARGS_VAR_NAME) {
             anyhow::bail!(
                 "the `{name}` variable is specified both via `{name}=...` and `-- ...`; use only one",
-                name = CLI_ARGS_VAR_NAME
+                name = TASK_ARGS_VAR_NAME
             );
         }
-        vars.insert(CLI_ARGS_VAR_NAME.to_string(), Value::String(cli_args.join(" ")));
+        vars.insert(TASK_ARGS_VAR_NAME.to_string(), Value::String(task_args.join(" ")));
     }
 
     Ok((tasks, vars))

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,6 +16,9 @@ use std::io::Write;
 use std::path;
 use tracing::info;
 
+/// Name of the variable that receives the CLI arguments passed after `--`.
+const CLI_ARGS_VAR_NAME: &str = "args";
+
 /// Firepit: Simple task & service runner with a comfortable TUI
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -24,6 +27,12 @@ pub struct Args {
     /// Variable are in "Name=Value" format (e.g. ENV=prod, DEBUG=true)
     #[arg(required = false)]
     pub tasks_or_vars: Vec<String>,
+
+    /// Extra arguments forwarded to tasks.
+    /// Everything after `--` is joined with spaces and assigned to the `args` variable,
+    /// so it can be referenced in task commands as `{{ args }}`.
+    #[arg(last = true)]
+    pub cli_args: Vec<String>,
 
     /// Working directory
     #[arg(short, long, default_value = ".")]
@@ -92,7 +101,7 @@ pub async fn run() -> anyhow::Result<i32> {
     // Arguments
     let args = Args::parse();
     let dir = path::absolute(&args.dir)?;
-    let (tasks, vars) = parse_tasks_or_vars(&args.tasks_or_vars)?;
+    let (tasks, vars) = parse_tasks_or_vars(&args.tasks_or_vars, &args.cli_args)?;
     let fail_fast = args.fail_fast();
 
     // Load config files
@@ -201,7 +210,10 @@ pub async fn run() -> anyhow::Result<i32> {
     exit_code
 }
 
-fn parse_tasks_or_vars(items: &[String]) -> anyhow::Result<(Vec<String>, IndexMap<String, Value>)> {
+fn parse_tasks_or_vars(
+    items: &[String],
+    cli_args: &[String],
+) -> anyhow::Result<(Vec<String>, IndexMap<String, Value>)> {
     let mut tasks = Vec::new();
     let mut vars = IndexMap::new();
     for item in items.iter() {
@@ -223,6 +235,19 @@ fn parse_tasks_or_vars(items: &[String]) -> anyhow::Result<(Vec<String>, IndexMa
             None => tasks.push(item.to_string()),
         }
     }
+
+    // Forward the arguments after `--` as the `args` variable (space-joined).
+    // This is just an alias for setting `args=...`, so specifying both is ambiguous and rejected.
+    if !cli_args.is_empty() {
+        if vars.contains_key(CLI_ARGS_VAR_NAME) {
+            anyhow::bail!(
+                "the `{name}` variable is specified both via `{name}=...` and `-- ...`; use only one",
+                name = CLI_ARGS_VAR_NAME
+            );
+        }
+        vars.insert(CLI_ARGS_VAR_NAME.to_string(), Value::String(cli_args.join(" ")));
+    }
+
     Ok((tasks, vars))
 }
 
@@ -338,7 +363,7 @@ mod tests {
             "flag=true".to_string(),
         ];
 
-        let (tasks, vars) = parse_tasks_or_vars(&inputs).unwrap();
+        let (tasks, vars) = parse_tasks_or_vars(&inputs, &[]).unwrap();
 
         assert_eq!(tasks, vec!["build".to_string()]);
         assert_eq!(vars.get("count"), Some(&json!(10)));
@@ -346,5 +371,35 @@ mod tests {
         assert_eq!(vars.get("raw"), Some(&json!("foo=bar")));
         assert_eq!(vars.get("single"), Some(&json!("baz=qux")));
         assert_eq!(vars.get("flag"), Some(&json!(true)));
+    }
+
+    #[test]
+    fn cli_args_after_dashes_are_joined_into_args_var() {
+        let inputs = vec!["test".to_string()];
+        let cli_args = vec!["--nocapture".to_string(), "my_test".to_string()];
+
+        let (tasks, vars) = parse_tasks_or_vars(&inputs, &cli_args).unwrap();
+
+        assert_eq!(tasks, vec!["test".to_string()]);
+        assert_eq!(vars.get("args"), Some(&json!("--nocapture my_test")));
+    }
+
+    #[test]
+    fn no_cli_args_does_not_inject_args_var() {
+        let inputs = vec!["test".to_string()];
+
+        let (_, vars) = parse_tasks_or_vars(&inputs, &[]).unwrap();
+
+        assert_eq!(vars.get("args"), None);
+    }
+
+    #[test]
+    fn specifying_args_both_ways_is_rejected() {
+        let inputs = vec!["test".to_string(), "args=foo".to_string()];
+        let cli_args = vec!["bar".to_string()];
+
+        let result = parse_tasks_or_vars(&inputs, &cli_args);
+
+        assert!(result.is_err());
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,8 +29,8 @@ pub struct Args {
     pub tasks_or_vars: Vec<String>,
 
     /// Extra arguments forwarded to tasks.
-    /// Everything after `--` is joined with spaces and assigned to the `args` variable,
-    /// so it can be referenced in task commands as `{{ args }}`.
+    /// Everything after `--` is shell-escaped, joined with spaces, and assigned to the
+    /// `args` variable, so it can be referenced in task commands as `{{ args }}`.
     #[arg(last = true, value_name = "ARGS")]
     pub task_args: Vec<String>,
 
@@ -236,7 +236,7 @@ fn parse_tasks_or_vars(
         }
     }
 
-    // Forward the arguments after `--` as the `args` variable (space-joined).
+    // Forward the arguments after `--` as the `args` variable (shell-escaped and space-joined).
     // This is just an alias for setting `args=...`, so specifying both is ambiguous and rejected.
     if !task_args.is_empty() {
         if vars.contains_key(TASK_ARGS_VAR_NAME) {
@@ -245,7 +245,10 @@ fn parse_tasks_or_vars(
                 name = TASK_ARGS_VAR_NAME
             );
         }
-        vars.insert(TASK_ARGS_VAR_NAME.to_string(), Value::String(task_args.join(" ")));
+        vars.insert(
+            TASK_ARGS_VAR_NAME.to_string(),
+            Value::String(shell_words::join(task_args)),
+        );
     }
 
     Ok((tasks, vars))
@@ -374,14 +377,23 @@ mod tests {
     }
 
     #[test]
-    fn cli_args_after_dashes_are_joined_into_args_var() {
+    fn cli_args_after_dashes_are_shell_escaped_into_args_var() {
         let inputs = vec!["test".to_string()];
-        let cli_args = vec!["--nocapture".to_string(), "my_test".to_string()];
+        let cli_args = vec![
+            "--filter".to_string(),
+            "my test".to_string(),
+            "quote's".to_string(),
+            "$(rm -rf /tmp)".to_string(),
+            "".to_string(),
+        ];
 
         let (tasks, vars) = parse_tasks_or_vars(&inputs, &cli_args).unwrap();
 
         assert_eq!(tasks, vec!["test".to_string()]);
-        assert_eq!(vars.get("args"), Some(&json!("--nocapture my_test")));
+        assert_eq!(
+            vars.get("args"),
+            Some(&json!("--filter 'my test' 'quote'\\''s' '$(rm -rf /tmp)' ''"))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Arguments after `--` on the CLI are now space-joined and assigned to the `args` variable, so they can be referenced in task commands as `{{ args }}` (similar to go-task's `CLI_ARGS`).
- `--` is intentionally implemented as **syntactic sugar for assigning the ordinary `args` user variable**, not a dedicated built-in. This lets the same variable be driven from two places: the CLI (`firepit test -- --nocapture`) and `depends_on` (`vars: { args: ... }`).
- Specifying `args` both via `args=...` and `-- ...` is rejected as ambiguous.

## Usage

```yaml
tasks:
  test:
    vars: { args: "" }
    command: cargo test {{ args }}
  ci:
    depends_on:
      - task: test
        vars: { args: "--release" }
```

- `firepit test -- --nocapture` → runs `cargo test --nocapture`
- `firepit ci` → runs `test` with `--release`. An explicit `depends_on` value takes precedence over a global `--` injection.

## Tests

- Added unit tests: injection, no-injection default, and double-spec error.
- Verified end-to-end in CUI mode.

## Docs

- `docs/cli.md`: documented the `[-- <ARGS>...]` usage and the `args` argument.
- `docs/configuration.md`: added a "Passing Arguments" section.
