### PR TITLE
fix: show partial task output before process exit

### DIFF
--- a/src/app/cui/output.rs
+++ b/src/app/cui/output.rs
@@ -21,13 +21,18 @@ pub struct OutputClient<W> {
     // We could use a RefCell if we didn't use this with async code.
     // Any locals held across an await must implement Sync and RwLock lets us achieve this
     buffer: Option<RwLock<Vec<SinkBytes<'static>>>>,
+    line_buffers: LineBuffers,
     writers: Arc<Mutex<SinkWriters<W>>>,
+}
+
+struct LineBuffers {
+    out: RwLock<Vec<u8>>,
+    err: RwLock<Vec<u8>>,
 }
 
 pub struct OutputWriter<'a, W> {
     logger: &'a OutputClient<W>,
     destination: Destination,
-    buffer: Vec<u8>,
 }
 
 /// Enum for controlling the behavior of the client
@@ -77,6 +82,10 @@ impl<W: Write> OutputSink<W> {
         OutputClient {
             behavior,
             buffer,
+            line_buffers: LineBuffers {
+                out: RwLock::new(Vec::new()),
+                err: RwLock::new(Vec::new()),
+            },
             writers,
         }
     }
@@ -89,7 +98,6 @@ impl<W: Write> OutputClient<W> {
         OutputWriter {
             logger: self,
             destination: Destination::Stdout,
-            buffer: Vec::new(),
         }
     }
 
@@ -99,7 +107,6 @@ impl<W: Write> OutputClient<W> {
         OutputWriter {
             logger: self,
             destination: Destination::Stderr,
-            buffer: Vec::new(),
         }
     }
 
@@ -160,31 +167,113 @@ impl<W: Write> OutputClient<W> {
         let buffer = self.buffer.as_ref().expect("attempted to add line to nil buffer");
         buffer.write().expect("lock poisoned").push(bytes);
     }
+
+    fn line_buffer(&self, destination: Destination) -> &RwLock<Vec<u8>> {
+        match destination {
+            Destination::Stdout => &self.line_buffers.out,
+            Destination::Stderr => &self.line_buffers.err,
+        }
+    }
 }
 
 impl<'a, W: Write> Write for OutputWriter<'a, W> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        for line in buf.split_inclusive(|b| *b == b'\n') {
-            self.buffer.extend_from_slice(line);
-            // If the line doesn't end in a newline we assume it isn't finished and add it
-            // to the buffer
-            if line.ends_with(b"\n") {
-                self.logger.handle_bytes(SinkBytes {
-                    buffer: self.buffer.as_slice().into(),
-                    destination: self.destination,
-                })?;
-                self.buffer.clear();
+        let mut ready = Vec::new();
+        let line_buffer = self.logger.line_buffer(self.destination);
+        {
+            let mut buffer = line_buffer.write().expect("lock poisoned");
+
+            for line in buf.split_inclusive(|b| *b == b'\n') {
+                buffer.extend_from_slice(line);
+                // If the line doesn't end in a newline we assume it isn't finished and add it
+                // to the buffer
+                if line.ends_with(b"\n") {
+                    ready.push(std::mem::take(&mut *buffer));
+                }
             }
         }
+
+        for line in ready {
+            self.logger.handle_bytes(SinkBytes {
+                buffer: line.into(),
+                destination: self.destination,
+            })?;
+        }
+
         Ok(buf.len())
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        self.logger.handle_bytes(SinkBytes {
-            buffer: self.buffer.as_slice().into(),
-            destination: self.destination,
-        })?;
-        self.buffer.clear();
+        let line = {
+            let line_buffer = self.logger.line_buffer(self.destination);
+            let mut buffer = line_buffer.write().expect("lock poisoned");
+            if buffer.is_empty() {
+                None
+            } else {
+                Some(std::mem::take(&mut *buffer))
+            }
+        };
+        if let Some(line) = line {
+            self.logger.handle_bytes(SinkBytes {
+                buffer: line.into(),
+                destination: self.destination,
+            })?;
+        }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{OutputClientBehavior, OutputSink};
+    use std::io::{self, Write};
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone, Default)]
+    struct SharedWriter {
+        bytes: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl SharedWriter {
+        fn bytes(&self) -> Vec<u8> {
+            self.bytes.lock().expect("lock poisoned").clone()
+        }
+    }
+
+    impl Write for SharedWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.bytes.lock().expect("lock poisoned").extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn passthrough_keeps_partial_stdout_across_writers() {
+        let stdout = SharedWriter::default();
+        let sink = OutputSink::new(stdout.clone(), SharedWriter::default());
+        let client = sink.logger(OutputClientBehavior::Passthrough);
+
+        client.stdout().write_all(b"Enter a value: ").unwrap();
+        assert!(stdout.bytes().is_empty());
+
+        client.stdout().write_all(b"\n").unwrap();
+        assert_eq!(stdout.bytes(), b"Enter a value: \n");
+    }
+
+    #[test]
+    fn passthrough_flushes_partial_stdout() {
+        let stdout = SharedWriter::default();
+        let sink = OutputSink::new(stdout.clone(), SharedWriter::default());
+        let client = sink.logger(OutputClientBehavior::Passthrough);
+
+        let mut writer = client.stdout();
+        writer.write_all(b"Enter a value: ").unwrap();
+        writer.flush().unwrap();
+
+        assert_eq!(stdout.bytes(), b"Enter a value: ");
     }
 }

--- a/src/process/child.rs
+++ b/src/process/child.rs
@@ -28,7 +28,7 @@ use super::{Command, PtySize};
 use crate::{tokio_spawn, tokio_spawn_blocking};
 use portable_pty::{native_pty_system, Child as PtyChild, MasterPty as PtyController};
 use tokio::{
-    io::{AsyncBufRead, AsyncBufReadExt, BufReader},
+    io::{AsyncRead, AsyncReadExt},
     join,
     process::Command as TokioCommand,
     sync::{mpsc, watch, RwLock},
@@ -554,13 +554,8 @@ impl Child {
     ) -> Result<Option<ChildExit>, io::Error> {
         match self.outputs() {
             Some(ChildOutput::Std { stdout, stderr }) => {
-                self.wait_with_piped_async_outputs(
-                    stdout_pipe,
-                    stderr_pipe,
-                    Some(BufReader::new(stdout)),
-                    Some(BufReader::new(stderr)),
-                )
-                .await
+                self.wait_with_piped_async_outputs(stdout_pipe, stderr_pipe, Some(stdout), Some(stderr))
+                    .await
             }
             Some(ChildOutput::Pty(output)) => {
                 self.wait_with_piped_sync_output(stdout_pipe, io::BufReader::new(output))
@@ -624,76 +619,72 @@ impl Child {
         Ok(status)
     }
 
-    async fn wait_with_piped_async_outputs<R1: AsyncBufRead + Unpin, R2: AsyncBufRead + Unpin>(
+    async fn wait_with_piped_async_outputs<R1: AsyncRead + Unpin, R2: AsyncRead + Unpin>(
         &mut self,
         mut stdout_pipe: impl Write,
         mut stderr_pipe: impl Write,
         mut stdout_lines: Option<R1>,
         mut stderr_lines: Option<R2>,
     ) -> Result<Option<ChildExit>, std::io::Error> {
-        async fn next_line<R: AsyncBufRead + Unpin>(
-            stream: &mut Option<R>,
-            buffer: &mut Vec<u8>,
-        ) -> Option<Result<(), io::Error>> {
-            match stream {
-                Some(stream) => match stream.read_until(b'\n', buffer).await {
-                    Ok(0) => {
-                        trace!("reached EOF");
-                        None
-                    }
-                    Ok(_) => Some(Ok(())),
-                    Err(e) => Some(Err(e)),
-                },
-                None => None,
+        enum StreamOutput {
+            Bytes(Vec<u8>),
+            Eof,
+        }
+
+        async fn next_chunk<R: AsyncRead + Unpin>(stream: &mut Option<R>) -> Option<Result<StreamOutput, io::Error>> {
+            let reader = stream.as_mut()?;
+            let mut buffer = [0; 1024];
+            match reader.read(&mut buffer).await {
+                Ok(0) => {
+                    trace!("reached EOF");
+                    stream.take();
+                    Some(Ok(StreamOutput::Eof))
+                }
+                Ok(n) => Some(Ok(StreamOutput::Bytes(buffer[..n].to_vec()))),
+                Err(e) => Some(Err(e)),
             }
         }
 
-        let mut stdout_buffer = Vec::new();
-        let mut stderr_buffer = Vec::new();
+        let mut last_stdout_byte = None;
+        let mut last_stderr_byte = None;
 
         let mut is_exited = false;
         loop {
             tokio::select! {
-                Some(result) = next_line(&mut stdout_lines, &mut stdout_buffer) => {
-                    trace!("processing stdout line");
-                    result?;
-                    add_trailing_newline(&mut stdout_buffer);
-                    stdout_pipe.write_all(&stdout_buffer)?;
-                    stdout_buffer.clear();
+                Some(result) = next_chunk(&mut stdout_lines) => {
+                    trace!("processing stdout chunk");
+                    match result? {
+                        StreamOutput::Bytes(bytes) => {
+                            last_stdout_byte = bytes.last().copied();
+                            write_output_chunks(&mut stdout_pipe, &bytes)?;
+                        }
+                        StreamOutput::Eof => {
+                            write_trailing_newline(&mut stdout_pipe, last_stdout_byte)?;
+                        }
+                    }
                 }
-                Some(result) = next_line(&mut stderr_lines, &mut stderr_buffer) => {
-                    trace!("processing stderr line");
-                    result?;
-                    add_trailing_newline(&mut stderr_buffer);
-                    stderr_pipe.write_all(&stderr_buffer)?;
-                    stderr_buffer.clear();
+                Some(result) = next_chunk(&mut stderr_lines) => {
+                    trace!("processing stderr chunk");
+                    match result? {
+                        StreamOutput::Bytes(bytes) => {
+                            last_stderr_byte = bytes.last().copied();
+                            write_output_chunks(&mut stderr_pipe, &bytes)?;
+                        }
+                        StreamOutput::Eof => {
+                            write_trailing_newline(&mut stderr_pipe, last_stderr_byte)?;
+                        }
+                    }
                 }
                 _status = self.wait(), if !is_exited => {
                     trace!("child process exited: {}", self.label());
                     is_exited = true;
                 }
                 else => {
-                    trace!("flushing child stdout/stderr buffers");
-                    // In the case that both futures read a complete line
-                    // the future not chosen in the select will return None if it's at EOF
-                    // as the number of bytes read will be 0.
-                    // We check and flush the buffers to avoid missing the last line of output.
-                    if !stdout_buffer.is_empty() {
-                        add_trailing_newline(&mut stdout_buffer);
-                        stdout_pipe.write_all(&stdout_buffer)?;
-                        stdout_buffer.clear();
-                    }
-                    if !stderr_buffer.is_empty() {
-                        add_trailing_newline(&mut stderr_buffer);
-                        stderr_pipe.write_all(&stderr_buffer)?;
-                        stderr_buffer.clear();
-                    }
+                    trace!("finished draining child stdout/stderr");
                     break;
                 }
             }
         }
-        debug_assert!(stdout_buffer.is_empty(), "buffer should be empty");
-        debug_assert!(stderr_buffer.is_empty(), "buffer should be empty");
 
         Ok(self.wait().await)
     }
@@ -703,14 +694,18 @@ impl Child {
     }
 }
 
-// Adds a trailing newline if necessary to the buffer
-fn add_trailing_newline(buffer: &mut Vec<u8>) {
-    // If the line doesn't end with a newline, that indicates we hit a EOF.
-    // We add a newline so output from other tasks doesn't get written to the same
-    // line.
-    if buffer.last() != Some(&b'\n') {
-        buffer.push(b'\n');
+fn write_trailing_newline(pipe: &mut impl Write, last_byte: Option<u8>) -> io::Result<()> {
+    if matches!(last_byte, Some(byte) if byte != b'\n') {
+        pipe.write_all(b"\n")?;
     }
+    Ok(())
+}
+
+fn write_output_chunks(pipe: &mut impl Write, bytes: &[u8]) -> io::Result<()> {
+    for chunk in bytes.split_inclusive(|byte| *byte == b'\n') {
+        pipe.write_all(chunk)?;
+    }
+    Ok(())
 }
 
 impl ChildStateManager {

--- a/tests/fixtures/runner/partial_output/firepit.yml
+++ b/tests/fixtures/runner/partial_output/firepit.yml
@@ -1,0 +1,5 @@
+tasks:
+  foo:
+    command: |
+      printf 'Enter a value: '
+      sleep 30

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -97,6 +97,54 @@ async fn test_basic_failure() {
 }
 
 #[tokio::test]
+async fn test_partial_output_without_newline_is_forwarded_before_exit() {
+    setup();
+    let path = path::absolute(BASE_PATH.join("partial_output")).unwrap();
+    let tasks = vec![String::from("foo")];
+    let (root, children) = ProjectConfig::new_multi(&path).unwrap();
+    let ws = Workspace::new(
+        &root,
+        &children,
+        &tasks,
+        &path,
+        &IndexMap::new(),
+        false,
+        false,
+        Some(false),
+        Some(false),
+    )
+    .await
+    .unwrap();
+
+    let mut runner = TaskRunner::new(&ws).unwrap();
+    let (app_tx, mut app_rx) = AppCommandChannel::new();
+    let runner_tx = runner.command_tx.clone();
+    let runner_fut = tokio::spawn(async move { runner.run(&app_tx, false).await });
+
+    let output = tokio::time::timeout(Duration::from_secs(1), async {
+        while let Some(event) = app_rx.recv().await {
+            match event {
+                AppCommand::TaskOutput { task, output } if task == "#foo" => {
+                    return String::from_utf8(output).unwrap();
+                }
+                AppCommand::FinishTask { task, .. } if task == "#foo" => {
+                    panic!("task finished before partial output was forwarded");
+                }
+                _ => {}
+            }
+        }
+        panic!("app command channel closed before partial output was forwarded");
+    })
+    .await
+    .expect("partial output was not forwarded before the task exited");
+
+    runner_tx.quit();
+    runner_fut.await.unwrap().unwrap();
+
+    assert_eq!(output, "Enter a value: ");
+}
+
+#[tokio::test]
 #[rstest]
 #[case("")]
 #[case("foo")]


### PR DESCRIPTION
## Summary
- Forward non-PTY task output chunks without waiting for newline-delimited lines
- Preserve line-oriented event boundaries for newline-terminated output
- Add regression coverage for prompts that do not end with a newline

## Testing
- cargo fmt -- --check
- cargo clippy -- -D warnings
- cargo test --test runner
- cargo test -- --test-threads=1

Note: default parallel `cargo test` exposed existing runner timeout flakiness; the full suite passed with `--test-threads=1`.