### PR TITLE
feat: support required template variables

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -93,6 +93,18 @@ tasks:
 Firepit performs template processing using [Tera](https://keats.github.io/tera/).
 Check the documentation for details about the template syntax.
 
+Set a variable without a value to make it required. Required variables must be
+provided explicitly from the CLI or a higher-priority `vars` entry; otherwise,
+config rendering fails before the task starts.
+
+```yaml
+tasks:
+  sops-decrypt:
+    vars:
+      env:
+    command: sops -d ../envs/{{ env }}/*.tfvars
+```
+
 Template processing is supported in the following fields:
 
 - `vars`

--- a/docs/schema-body.md
+++ b/docs/schema-body.md
@@ -164,6 +164,11 @@ vars:
   aws_region: ap-northeast-1
   ecr_registry: "{{ aws_account_id }}.dkr.ecr.{{ aws_region }}.amazonaws.com"
 ```
+A variable with no value is required and must be provided explicitly.
+```yaml
+vars:
+  env:
+```
 
 ### working_dir
 
@@ -245,6 +250,7 @@ If omitted, all tasks are matched.
 - **Default:** `{}`
 - **Template:** yes
 - **Description:** Template variables
+A variable with no value is required and must be provided explicitly.
 
 ### working_dir
 
@@ -552,6 +558,7 @@ Probe failure during that period will not be counted towards the maximum number 
 - **Description:** Template variables. Merged with the project `vars`.
 Can be used at `label`, `command`, `working_dir`, `env`, `env_files`, `depends_on`, `depends_on.{task, vars}`,
 `service.healthcheck.log` and `service.healthcheck.exec.{command, working_dir, env, env_files}`
+A variable with no value is required and must be provided explicitly.
 
 ### working_dir
 

--- a/schema.json
+++ b/schema.json
@@ -105,7 +105,7 @@
       "default": "cui"
     },
     "vars": {
-      "description": "Template variables for all the project tasks.\n```yaml\nvars:\n  aws_account_id: 123456789012\n  aws_region: ap-northeast-1\n  ecr_registry: \"{{ aws_account_id }}.dkr.ecr.{{ aws_region }}.amazonaws.com\"\n```",
+      "description": "Template variables for all the project tasks.\n```yaml\nvars:\n  aws_account_id: 123456789012\n  aws_region: ap-northeast-1\n  ecr_registry: \"{{ aws_account_id }}.dkr.ecr.{{ aws_region }}.amazonaws.com\"\n```\nA variable with no value is required and must be provided explicitly.\n```yaml\nvars:\n  env:\n```",
       "type": "object",
       "additionalProperties": {
         "$ref": "#/$defs/VarsConfig"
@@ -203,7 +203,7 @@
           ]
         },
         "vars": {
-          "description": "Template variables",
+          "description": "Template variables\nA variable with no value is required and must be provided explicitly.",
           "type": "object",
           "additionalProperties": {
             "$ref": "#/$defs/VarsConfig"
@@ -593,7 +593,7 @@
           ]
         },
         "vars": {
-          "description": "Template variables. Merged with the project `vars`.\nCan be used at `label`, `command`, `working_dir`, `env`, `env_files`, `depends_on`, `depends_on.{task, vars}`,\n`service.healthcheck.log` and `service.healthcheck.exec.{command, working_dir, env, env_files}`",
+          "description": "Template variables. Merged with the project `vars`.\nCan be used at `label`, `command`, `working_dir`, `env`, `env_files`, `depends_on`, `depends_on.{task, vars}`,\n`service.healthcheck.log` and `service.healthcheck.exec.{command, working_dir, env, env_files}`\nA variable with no value is required and must be provided explicitly.",
           "type": "object",
           "additionalProperties": {
             "$ref": "#/$defs/VarsConfig"

--- a/src/config.rs
+++ b/src/config.rs
@@ -422,7 +422,9 @@ impl ProjectConfig {
 
     pub fn schema() -> anyhow::Result<String> {
         let schema = schemars::schema_for!(ProjectConfig);
-        serde_json::to_string_pretty(&schema).context("cannot create config schema")
+        let mut schema = serde_json::to_string_pretty(&schema).context("cannot create config schema")?;
+        schema.push('\n');
+        Ok(schema)
     }
 
     pub fn task(&self, name: &str) -> anyhow::Result<&TaskConfig> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -68,6 +68,11 @@ pub struct ProjectConfig {
     ///   aws_region: ap-northeast-1
     ///   ecr_registry: "{{ aws_account_id }}.dkr.ecr.{{ aws_region }}.amazonaws.com"
     /// ```
+    /// A variable with no value is required and must be provided explicitly.
+    /// ```yaml
+    /// vars:
+    ///   env:
+    /// ```
     #[serde(default)]
     #[schemars(extend("x-template" = true))]
     pub vars: IndexMap<String, VarsConfig>,
@@ -609,6 +614,7 @@ pub struct TaskConfig {
     /// Template variables. Merged with the project `vars`.
     /// Can be used at `label`, `command`, `working_dir`, `env`, `env_files`, `depends_on`, `depends_on.{task, vars}`,
     /// `service.healthcheck.log` and `service.healthcheck.exec.{command, working_dir, env, env_files}`
+    /// A variable with no value is required and must be provided explicitly.
     #[serde(default)]
     #[schemars(extend("x-template" = true))]
     pub vars: IndexMap<String, VarsConfig>,
@@ -1074,6 +1080,7 @@ pub struct DefaultsConfig {
     pub working_dir: Option<String>,
 
     /// Template variables
+    /// A variable with no value is required and must be provided explicitly.
     #[serde(default)]
     #[schemars(extend("x-template" = true))]
     pub vars: IndexMap<String, VarsConfig>,

--- a/src/template.rs
+++ b/src/template.rs
@@ -48,6 +48,10 @@ impl ProjectConfig {
         {
             let rk = tera.render_str(k, &context)?;
             if !rk.is_empty() {
+                if let Some(rv) = required_var_value(&rk, v, &context)? {
+                    context.insert(rk, &rv);
+                    continue;
+                }
                 let v = match v {
                     VarsConfig::Dynamic(s) => {
                         let mut s = s.clone();
@@ -127,6 +131,10 @@ impl TaskConfig {
         for (k, v) in self.vars.iter() {
             let rk = tera.render_str(k, &context)?;
             if !rk.is_empty() {
+                if let Some(rv) = required_var_value(&rk, v, &context)? {
+                    context.insert(rk, &rv);
+                    continue;
+                }
                 let v = match v {
                     VarsConfig::Dynamic(s) => {
                         let mut s = s.clone();
@@ -559,11 +567,26 @@ async fn render_value_map(
     for (k, v) in map.iter() {
         let rk = tera.render_str(k, context)?;
         if !rk.is_empty() {
-            let rv = VarsConfig::Static(render_value(v, tera, context).await?);
+            let rv = match required_var_value(&rk, v, context)? {
+                Some(value) => VarsConfig::Static(value),
+                None => VarsConfig::Static(render_value(v, tera, context).await?),
+            };
             ret.insert(rk, rv);
         }
     }
     Ok(ret)
+}
+
+fn required_var_value(name: &str, value: &VarsConfig, context: &tera::Context) -> anyhow::Result<Option<JsonValue>> {
+    if !matches!(value, VarsConfig::Static(JsonValue::Null)) {
+        return Ok(None);
+    }
+
+    let Some(value) = context.get(name).filter(|value| !value.is_null()) else {
+        anyhow::bail!("required var {:?} is not specified", name);
+    };
+
+    Ok(Some(value.clone()))
 }
 
 #[async_recursion]

--- a/tests/fixtures/runner/vars_required/firepit.yml
+++ b/tests/fixtures/runner/vars_required/firepit.yml
@@ -1,0 +1,7 @@
+tasks:
+  required:
+    vars:
+      env:
+    command: |
+      echo "{{ env }}"
+      echo "{% if env is string %}ok{% endif %}"

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -202,6 +202,40 @@ async fn test_vars_from_cli() {
 }
 
 #[tokio::test]
+async fn test_vars_required_from_cli() {
+    setup();
+
+    let path = BASE_PATH.join("vars_required");
+    let tasks = vec![String::from("required")];
+
+    let mut stats = HashMap::new();
+    stats.insert(String::from("#required"), String::from("Finished: Success"));
+
+    let mut outputs = HashMap::new();
+    outputs.insert(String::from("#required"), String::from("dev\nok"));
+
+    let vars = IndexMap::from([("env".to_string(), VarsConfig::Static(Value::from("dev")))]);
+    run_task_with_vars(&path, tasks, stats, Some(outputs), vars, false)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_vars_required_missing() {
+    setup();
+
+    let path = BASE_PATH.join("vars_required");
+    let result = run_task(&path, vec![String::from("required")], HashMap::new(), None, false).await;
+
+    let err = result.expect_err("required vars without values should fail");
+    assert!(
+        format!("{:#}", err).contains("required var \"env\" is not specified"),
+        "unexpected error: {:#}",
+        err
+    );
+}
+
+#[tokio::test]
 async fn test_vars_builtin() {
     setup();
 


### PR DESCRIPTION
## Summary

- Treat vars declared without a default value as required template variables.
- Reuse explicitly provided values from higher-priority vars instead of failing render.
- Document the required-var marker and update generated schema documentation.
- Add runner coverage for both provided and missing required vars.

## Why

Tasks can currently reference vars such as `{{ env }}`, but rendering fails with a low-level Tera error when the value is not provided. Declaring the var explicitly without a default value gives users a lightweight way to mark it as required and get a clearer configuration error.

## Validation

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`

The commit hook also ran successfully after trusting the repository `mise.toml`.