### PR TITLE
fix: default task label to the original name without variant suffix

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -252,6 +252,7 @@ tasks:
 ```
 
 Each dependent runs its own variant of `migrate` with the overridden variables.
+In the TUI/CUI, every variant is displayed with the original task name by default; set a `label` with template variables (for example `label: "migrate {{ database }}"`) to tell the variants apart.
 Note that only variables already declared in the dependency task can be overridden, so `migrate` must declare `database` in its `vars`.
 If the same variable is also injected globally via `--` (see [Passing Arguments](#passing-arguments)), the value specified here on the dependency takes precedence.
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -426,7 +426,12 @@ impl Task {
 
         Ok(Self {
             name: Task::qualified_name(project_name, &task_name),
-            label: task_config.label.clone().unwrap_or(task_name.clone()),
+            // Default to the original name so that task variants do not expose
+            // their internal suffix (-1, -2, ...) in the UI
+            label: task_config
+                .label
+                .clone()
+                .unwrap_or_else(|| Task::qualified_name(project_name, &task_config.orig_name)),
             command: task_config.command.clone().unwrap_or("".to_string()),
             shell: task_shell.command,
             shell_args: task_shell.args,

--- a/tests/fixtures/project/variant_label/firepit.yml
+++ b/tests/fixtures/project/variant_label/firepit.yml
@@ -1,0 +1,23 @@
+# Test that the default label of a task variant is the original task name
+# without the internal variant suffix (-1, -2, ...).
+tasks:
+  foo:
+    command: echo foo
+    depends_on:
+      - task: bar
+        vars:
+          A: 2
+      - task: baz
+        vars:
+          A: 2
+
+  bar:
+    vars:
+      A: 1
+    command: echo "bar {{ A }}"
+
+  baz:
+    label: "baz {{ A }}"
+    vars:
+      A: 1
+    command: echo "baz {{ A }}"

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -64,6 +64,32 @@ async fn test_bad_env_file() {
 }
 
 #[tokio::test]
+async fn test_variant_label() {
+    let path = Path::new("tests/fixtures/project/variant_label");
+    let (root, children) = ProjectConfig::new_multi(path).unwrap();
+    let ws = Workspace::new(
+        &root,
+        &children,
+        &[String::from("#foo")],
+        &std::env::current_dir().unwrap(),
+        &IndexMap::new(),
+        false,
+        false,
+        Some(false),
+        Some(false),
+    )
+    .await
+    .unwrap();
+
+    let labels = ws.labels();
+    // Default labels do not include the internal variant suffix
+    assert_eq!(labels.get("#foo"), Some(&String::from("#foo")));
+    assert_eq!(labels.get("#bar-1"), Some(&String::from("#bar")));
+    // Explicit labels are rendered with the variant vars
+    assert_eq!(labels.get("#baz-1"), Some(&String::from("baz 2")));
+}
+
+#[tokio::test]
 async fn test_multi() {
     let path = Path::new("tests/fixtures/project/multi");
     let (root, children) = ProjectConfig::new_multi(path).unwrap();


### PR DESCRIPTION
## Summary

Task variants are managed internally with sequentially numbered suffixes (`-1`, `-2`, ...), and when no `label` was set, this internal suffix leaked into the TUI/CUI display (task list, log prefixes, pane titles). The suffix exists only for internal bookkeeping and should not be shown to users, so the default label now falls back to the original task name via `TaskConfig.orig_name`.

Explicit labels are unaffected: they are still rendered with each variant's vars, so `label: "migrate {{ database }}"` can be used to tell variants apart.

## Changes

- Default the task label to the (project-qualified) original name instead of the variant name in `Task::new`
- Document that all variants share the original task name by default and how to distinguish them with a templated `label`

## How to verify

- `cargo test --all --locked` — includes the new `test_variant_label` test with the `tests/fixtures/project/variant_label/` fixture
- `cargo run --bin firepit -- -d tests/fixtures/project/variant_label --cui foo` — the `bar` variant's log prefix is now `#bar` (previously `#bar-1`)

## Checklist

- [x] `cargo test --all --locked` passes (tests are not covered by git hooks)
- [x] Added or updated tests for behavior changes (fixtures go under `tests/fixtures/`)
- [x] Updated docs (`docs/`) and examples (`examples/`) if user-facing behavior changed