### PR TITLE
fix(config): preserve empty string template variables

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -574,6 +574,9 @@ async fn render_value(value: &VarsConfig, tera: &mut Tera, context: &tera::Conte
                 let str = tera
                     .render_str(s, context)
                     .context(format!("failed to render {:?}", s))?;
+                if str.is_empty() {
+                    return Ok(JsonValue::String(str));
+                }
                 let yaml_value =
                     serde_yaml::from_str::<Value>(&str).context(format!("failed to read YAML value {:?}", str))?;
                 match yaml_value {

--- a/tests/fixtures/project/task_empty_args_label/firepit.yml
+++ b/tests/fixtures/project/task_empty_args_label/firepit.yml
@@ -1,0 +1,7 @@
+tasks:
+  tf:
+    label: "{{ task }} {{ args | split(pat=' ') | first }}"
+    vars:
+      env:
+      args: ""
+    command: echo "{{ env }} {{ args }}"

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -90,6 +90,28 @@ async fn test_variant_label() {
 }
 
 #[tokio::test]
+async fn test_empty_string_task_var_renders_as_string_in_label() {
+    let path = Path::new("tests/fixtures/project/task_empty_args_label");
+    let (root, children) = ProjectConfig::new_multi(path).unwrap();
+    let ws = Workspace::new(
+        &root,
+        &children,
+        &[String::from("#tf")],
+        &std::env::current_dir().unwrap(),
+        &IndexMap::new(),
+        false,
+        false,
+        Some(false),
+        Some(false),
+    )
+    .await
+    .unwrap();
+
+    let labels = ws.labels();
+    assert_eq!(labels.get("#tf"), Some(&String::from("#tf ")));
+}
+
+#[tokio::test]
 async fn test_multi() {
     let path = Path::new("tests/fixtures/project/multi");
     let (root, children) = ProjectConfig::new_multi(path).unwrap();


### PR DESCRIPTION
## Summary
- Keep explicitly empty string vars as strings during template rendering
- Add a regression fixture covering label rendering with `args: ""`

## Testing
- `cargo test --test project test_empty_string_task_var_renders_as_string_in_label --locked`
- `cargo fmt --check`
- `cargo test --all --locked`