### PR TITLE
feat(cli): add no-log-prefix for CUI logs

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -73,3 +73,8 @@ Force TUI mode, even if tty is not detected.
 ### `--cui`
 
 Force CUI mode, even if tty is detected.
+
+### `--no-log-prefix`
+
+Disable task label prefixes in CUI log output.
+This is useful when piping task logs to external tools that expect raw JSON Lines or other unprefixed output.

--- a/src/app/cui/mod.rs
+++ b/src/app/cui/mod.rs
@@ -31,6 +31,7 @@ pub struct CuiApp {
     labels: HashMap<String, String>,
     quit_on_done: bool,
     fail_fast: bool,
+    no_log_prefix: bool,
 }
 
 impl CuiApp {
@@ -39,6 +40,7 @@ impl CuiApp {
         labels: &HashMap<String, String>,
         quit_on_done: bool,
         fail_fast: bool,
+        no_log_prefix: bool,
     ) -> anyhow::Result<Self> {
         let (command_tx, command_rx) = AppCommandChannel::new();
         Ok(Self {
@@ -51,12 +53,17 @@ impl CuiApp {
             labels: labels.clone(),
             fail_fast,
             quit_on_done,
+            no_log_prefix,
         })
     }
 
     fn register_output_client(&mut self, task: &str) {
         let task = task.to_string();
-        let prefix = self.labels.get(&task).unwrap_or(&task);
+        let prefix = if self.no_log_prefix {
+            ""
+        } else {
+            self.labels.get(&task).unwrap_or(&task)
+        };
         let out = PrefixedWriter::new(
             ColorConfig::infer(),
             self.color_selector.string_with_color(prefix, prefix),

--- a/src/app/cui/prefixed.rs
+++ b/src/app/cui/prefixed.rs
@@ -45,3 +45,38 @@ impl<W: Write> Write for PrefixedWriter<W> {
         self.writer.flush()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::PrefixedWriter;
+    use crate::app::cui::lib::ColorConfig;
+    use console::Style;
+    use std::io::Write;
+
+    #[test]
+    fn non_empty_prefix_writes_label_before_each_line() {
+        let mut output = Vec::new();
+        {
+            let prefix = Style::new().apply_to("task: ");
+            let mut writer = PrefixedWriter::new(ColorConfig::new(true), prefix, &mut output);
+
+            writer.write_all(b"first\n").unwrap();
+            writer.write_all(b"second\n").unwrap();
+        }
+
+        assert_eq!(output, b"task: first\ntask: second\n");
+    }
+
+    #[test]
+    fn empty_prefix_writes_log_bytes_without_label() {
+        let mut output = Vec::new();
+        {
+            let prefix = Style::new().apply_to(String::new());
+            let mut writer = PrefixedWriter::new(ColorConfig::new(true), prefix, &mut output);
+
+            writer.write_all(b"first\nsecond\n").unwrap();
+        }
+
+        assert_eq!(output, b"first\nsecond\n");
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -80,6 +80,10 @@ pub struct Args {
     #[arg(long, conflicts_with = "tui")]
     pub cui: bool,
 
+    /// Disable task label prefixes in CUI log output
+    #[arg(long, default_value = "false")]
+    pub no_log_prefix: bool,
+
     /// Enable instrumentation for tokio-console
     #[arg(long, hide = true, default_value = "false")]
     pub tokio_console: bool,
@@ -166,7 +170,13 @@ pub async fn run() -> anyhow::Result<i32> {
     // Create & start UI
     let (app_tx, app_fut) = match root.ui {
         UI::Cui => {
-            let mut app = CuiApp::new(&runner.target_tasks, &ws.labels(), !args.watch, ws.fail_fast)?;
+            let mut app = CuiApp::new(
+                &runner.target_tasks,
+                &ws.labels(),
+                !args.watch,
+                ws.fail_fast,
+                args.no_log_prefix,
+            )?;
             let runner_tx = runner.command_tx();
             let command_tx = app.command_tx();
             let fut = tokio_spawn!("app", async move { app.run(&runner_tx).await });


### PR DESCRIPTION
## Summary

- Add a `--no-log-prefix` CLI option for CUI mode
- Allow CUI task output to be emitted without task label prefixes
- Document the new option and cover prefixed/unprefixed writer behavior

## Testing

- `cargo test app::cui::prefixed::tests`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all --locked`